### PR TITLE
Fix all formatting and clippy warnings

### DIFF
--- a/disentangle-cli/src/client.rs
+++ b/disentangle-cli/src/client.rs
@@ -89,7 +89,8 @@ mod tests {
                 let msg = e.to_string();
                 assert!(
                     msg.contains("error") || msg.contains("connect") || msg.contains("Connection"),
-                    "Expected connection error, got: {}", msg
+                    "Expected connection error, got: {}",
+                    msg
                 );
             }
             other => panic!("Expected CliError::RequestFailed, got: {:?}", other),

--- a/disentangle-cli/src/commands/cap.rs
+++ b/disentangle-cli/src/commands/cap.rs
@@ -1,7 +1,7 @@
-use clap::Subcommand;
-use crate::client::{NodeClient, CliResult, CliError};
+use crate::client::{CliError, CliResult, NodeClient};
 use crate::keys;
 use crate::output::OutputFormat;
+use clap::Subcommand;
 
 /// Resolve signing key: use explicit --signing-key-hex if given, otherwise load from --did key storage.
 fn resolve_signing_key(signing_key_hex: Option<String>, did: Option<&String>) -> CliResult<String> {
@@ -9,8 +9,7 @@ fn resolve_signing_key(signing_key_hex: Option<String>, did: Option<&String>) ->
         Some(sk) => Ok(sk),
         None => {
             let did = did.ok_or(CliError::MissingKey)?;
-            keys::load_key(did)?
-                .ok_or_else(|| CliError::KeyNotFound(did.clone()))
+            keys::load_key(did)?.ok_or_else(|| CliError::KeyNotFound(did.clone()))
         }
     }
 }
@@ -109,13 +108,9 @@ pub fn handle(cmd: CapCommands, client: &NodeClient, format: &OutputFormat) -> C
             let sk_hex = resolve_signing_key(signing_key_hex, did.as_ref().or(Some(&issuer_did)))?;
 
             let subject_val: serde_json::Value = serde_json::from_str(&subject)
-                .map_err(|e| CliError::NodeError(
-                    format!("Invalid subject JSON: {}", e)
-                ))?;
+                .map_err(|e| CliError::NodeError(format!("Invalid subject JSON: {}", e)))?;
             let constraints_val: serde_json::Value = serde_json::from_str(&constraints)
-                .map_err(|e| CliError::NodeError(
-                    format!("Invalid constraints JSON: {}", e)
-                ))?;
+                .map_err(|e| CliError::NodeError(format!("Invalid constraints JSON: {}", e)))?;
 
             let body = serde_json::json!({
                 "issuer_did": issuer_did,
@@ -135,7 +130,8 @@ pub fn handle(cmd: CapCommands, client: &NodeClient, format: &OutputFormat) -> C
             did,
             delegatee_did,
         } => {
-            let sk_hex = resolve_signing_key(delegator_sk_hex, did.as_ref().or(Some(&delegator_did)))?;
+            let sk_hex =
+                resolve_signing_key(delegator_sk_hex, did.as_ref().or(Some(&delegator_did)))?;
 
             let body = serde_json::json!({
                 "capability_id_hex": capability_id,

--- a/disentangle-cli/src/commands/curvature.rs
+++ b/disentangle-cli/src/commands/curvature.rs
@@ -1,6 +1,6 @@
-use clap::Subcommand;
-use crate::client::{NodeClient, CliResult, CliError};
+use crate::client::{CliError, CliResult, NodeClient};
 use crate::output::OutputFormat;
+use clap::Subcommand;
 
 #[derive(Subcommand)]
 pub enum CurvatureCommands {
@@ -33,11 +33,9 @@ pub fn handle(cmd: CurvatureCommands, client: &NodeClient, format: &OutputFormat
             format.print(&resp);
             Ok(())
         }
-        CurvatureCommands::Stats => {
-            Err(CliError::NotImplemented(
-                "Curvature statistics are not yet supported by the node RPC".to_string()
-            ))
-        }
+        CurvatureCommands::Stats => Err(CliError::NotImplemented(
+            "Curvature statistics are not yet supported by the node RPC".to_string(),
+        )),
         CurvatureCommands::Profile { did } => {
             let resp = client.get(&format!("/coherence/{}", did))?;
             format.print(&resp);

--- a/disentangle-cli/src/commands/gov.rs
+++ b/disentangle-cli/src/commands/gov.rs
@@ -1,7 +1,7 @@
-use clap::Subcommand;
-use crate::client::{NodeClient, CliResult, CliError};
+use crate::client::{CliError, CliResult, NodeClient};
 use crate::keys;
 use crate::output::OutputFormat;
+use clap::Subcommand;
 
 #[derive(Subcommand)]
 pub enum GovCommands {

--- a/disentangle-cli/src/commands/identity.rs
+++ b/disentangle-cli/src/commands/identity.rs
@@ -1,7 +1,7 @@
-use clap::Subcommand;
-use crate::client::{NodeClient, CliResult, CliError};
+use crate::client::{CliError, CliResult, NodeClient};
 use crate::keys;
 use crate::output::OutputFormat;
+use clap::Subcommand;
 
 #[derive(Subcommand)]
 pub enum IdentityCommands {
@@ -31,7 +31,10 @@ pub enum IdentityCommands {
 
 pub fn handle(cmd: IdentityCommands, client: &NodeClient, format: &OutputFormat) -> CliResult<()> {
     match cmd {
-        IdentityCommands::Create { agent_type, display_name } => {
+        IdentityCommands::Create {
+            agent_type,
+            display_name,
+        } => {
             let body = serde_json::json!({
                 "agent_type": agent_type,
                 "display_name": display_name.unwrap_or_default(),
@@ -83,10 +86,9 @@ pub fn handle(cmd: IdentityCommands, client: &NodeClient, format: &OutputFormat)
 
             Ok(())
         }
-        IdentityCommands::Rotate { did } => {
-            Err(CliError::NotImplemented(format!(
-                "Key rotation for DID {} is not yet supported by the node RPC", did
-            )))
-        }
+        IdentityCommands::Rotate { did } => Err(CliError::NotImplemented(format!(
+            "Key rotation for DID {} is not yet supported by the node RPC",
+            did
+        ))),
     }
 }

--- a/disentangle-cli/src/commands/mod.rs
+++ b/disentangle-cli/src/commands/mod.rs
@@ -1,7 +1,7 @@
-pub mod identity;
-pub mod tx;
-pub mod curvature;
 pub mod cap;
-pub mod petname;
+pub mod curvature;
 pub mod gov;
+pub mod identity;
 pub mod node;
+pub mod petname;
+pub mod tx;

--- a/disentangle-cli/src/commands/node.rs
+++ b/disentangle-cli/src/commands/node.rs
@@ -1,6 +1,6 @@
-use clap::Subcommand;
-use crate::client::{NodeClient, CliResult, CliError};
+use crate::client::{CliError, CliResult, NodeClient};
 use crate::output::OutputFormat;
+use clap::Subcommand;
 
 #[derive(Subcommand)]
 pub enum NodeCommands {
@@ -28,11 +28,9 @@ pub fn handle(cmd: NodeCommands, client: &NodeClient, format: &OutputFormat) -> 
             format.print(&resp);
             Ok(())
         }
-        NodeCommands::Peers => {
-            Err(CliError::NotImplemented(
-                "Peer listing is not yet supported by the node RPC".to_string()
-            ))
-        }
+        NodeCommands::Peers => Err(CliError::NotImplemented(
+            "Peer listing is not yet supported by the node RPC".to_string(),
+        )),
         NodeCommands::DagStats => {
             // Extract stats from the /graph endpoint
             let graph = client.get("/graph")?;

--- a/disentangle-cli/src/commands/petname.rs
+++ b/disentangle-cli/src/commands/petname.rs
@@ -1,7 +1,7 @@
-use clap::Subcommand;
-use crate::client::{NodeClient, CliResult, CliError};
+use crate::client::{CliError, CliResult, NodeClient};
 use crate::keys;
 use crate::output::OutputFormat;
+use clap::Subcommand;
 
 #[derive(Subcommand)]
 pub enum PetnameCommands {
@@ -60,11 +60,9 @@ pub fn handle(cmd: PetnameCommands, client: &NodeClient, format: &OutputFormat) 
             format.print(&resp);
             Ok(())
         }
-        PetnameCommands::List => {
-            Err(CliError::NotImplemented(
-                "Petname listing is not yet supported by the node RPC".to_string()
-            ))
-        }
+        PetnameCommands::List => Err(CliError::NotImplemented(
+            "Petname listing is not yet supported by the node RPC".to_string(),
+        )),
         PetnameCommands::Introduce {
             introducer_did,
             introducer_sk_hex,

--- a/disentangle-cli/src/commands/tx.rs
+++ b/disentangle-cli/src/commands/tx.rs
@@ -1,6 +1,6 @@
-use clap::Subcommand;
-use crate::client::{NodeClient, CliResult, CliError};
+use crate::client::{CliError, CliResult, NodeClient};
 use crate::output::OutputFormat;
+use clap::Subcommand;
 
 #[derive(Subcommand)]
 pub enum TxCommands {
@@ -40,7 +40,11 @@ pub enum TxCommands {
 
 pub fn handle(cmd: TxCommands, client: &NodeClient, format: &OutputFormat) -> CliResult<()> {
     match cmd {
-        TxCommands::Submit { sender, parents, data } => {
+        TxCommands::Submit {
+            sender,
+            parents,
+            data,
+        } => {
             let body = serde_json::json!({
                 "sender": sender,
                 "parents": parents,
@@ -87,10 +91,9 @@ pub fn handle(cmd: TxCommands, client: &NodeClient, format: &OutputFormat) -> Cl
             }
             Ok(())
         }
-        TxCommands::Mass { tx_id } => {
-            Err(CliError::NotImplemented(format!(
-                "Transaction mass query for {} is not yet supported by the node RPC", tx_id
-            )))
-        }
+        TxCommands::Mass { tx_id } => Err(CliError::NotImplemented(format!(
+            "Transaction mass query for {} is not yet supported by the node RPC",
+            tx_id
+        ))),
     }
 }

--- a/disentangle-cli/src/keys.rs
+++ b/disentangle-cli/src/keys.rs
@@ -1,5 +1,5 @@
-use std::path::{Path, PathBuf};
 use std::fs;
+use std::path::{Path, PathBuf};
 
 const KEYS_DIR: &str = ".disentangle/keys";
 

--- a/disentangle-cli/src/main.rs
+++ b/disentangle-cli/src/main.rs
@@ -117,13 +117,21 @@ mod tests {
     #[test]
     fn parse_identity_create_with_options() {
         let cli = try_parse(&[
-            "disentangle", "identity", "create",
-            "--agent-type", "agi",
-            "--display-name", "TestBot",
-        ]).unwrap();
+            "disentangle",
+            "identity",
+            "create",
+            "--agent-type",
+            "agi",
+            "--display-name",
+            "TestBot",
+        ])
+        .unwrap();
         if let Commands::Identity { command } = cli.command {
             match command {
-                commands::identity::IdentityCommands::Create { agent_type, display_name } => {
+                commands::identity::IdentityCommands::Create {
+                    agent_type,
+                    display_name,
+                } => {
                     assert_eq!(agent_type, "agi");
                     assert_eq!(display_name, Some("TestBot".to_string()));
                 }
@@ -158,14 +166,24 @@ mod tests {
     #[test]
     fn parse_tx_submit() {
         let cli = try_parse(&[
-            "disentangle", "tx", "submit",
-            "--sender", "alice",
-            "--parents", "aabb,ccdd",
-            "--data", "hello world",
-        ]).unwrap();
+            "disentangle",
+            "tx",
+            "submit",
+            "--sender",
+            "alice",
+            "--parents",
+            "aabb,ccdd",
+            "--data",
+            "hello world",
+        ])
+        .unwrap();
         if let Commands::Tx { command } = cli.command {
             match command {
-                commands::tx::TxCommands::Submit { sender, parents, data } => {
+                commands::tx::TxCommands::Submit {
+                    sender,
+                    parents,
+                    data,
+                } => {
                     assert_eq!(sender, "alice");
                     assert_eq!(parents, vec!["aabb", "ccdd"]);
                     assert_eq!(data, "hello world");
@@ -213,7 +231,14 @@ mod tests {
 
     #[test]
     fn parse_petname_set() {
-        let cli = try_parse(&["disentangle", "petname", "set", "alice", "did:disentangle:abc"]).unwrap();
+        let cli = try_parse(&[
+            "disentangle",
+            "petname",
+            "set",
+            "alice",
+            "did:disentangle:abc",
+        ])
+        .unwrap();
         if let Commands::Petname { command } = cli.command {
             match command {
                 commands::petname::PetnameCommands::Set { name, did } => {
@@ -253,27 +278,25 @@ mod tests {
     #[test]
     fn parse_custom_node_url() {
         let cli = try_parse(&[
-            "disentangle", "--node", "http://mynode:8080",
-            "node", "status",
-        ]).unwrap();
+            "disentangle",
+            "--node",
+            "http://mynode:8080",
+            "node",
+            "status",
+        ])
+        .unwrap();
         assert_eq!(cli.node, "http://mynode:8080");
     }
 
     #[test]
     fn parse_json_format() {
-        let cli = try_parse(&[
-            "disentangle", "--format", "json",
-            "node", "status",
-        ]).unwrap();
+        let cli = try_parse(&["disentangle", "--format", "json", "node", "status"]).unwrap();
         assert!(matches!(cli.format, OutputFormat::Json));
     }
 
     #[test]
     fn parse_human_format_explicit() {
-        let cli = try_parse(&[
-            "disentangle", "--format", "human",
-            "node", "status",
-        ]).unwrap();
+        let cli = try_parse(&["disentangle", "--format", "human", "node", "status"]).unwrap();
         assert!(matches!(cli.format, OutputFormat::Human));
     }
 

--- a/disentangle-consensus/src/lib.rs
+++ b/disentangle-consensus/src/lib.rs
@@ -24,13 +24,15 @@
 //! compute_topological_mass_verified() --> MassResult with verified_claims
 //! ```
 
-use std::collections::HashMap;
-use disentangle_dag::{TransactionDAG, FixedPoint, SCALE, fp_mul, fp_from_ratio};
 use disentangle_crypto::hash::Hash256;
-use disentangle_zkp::{ReputationClaim, ReputationVerifier, bucket_weight};
+use disentangle_dag::{fp_from_ratio, fp_mul, FixedPoint, TransactionDAG, SCALE};
+use disentangle_zkp::{bucket_weight, ReputationClaim, ReputationVerifier};
+use std::collections::HashMap;
 
 // Re-export ZKP types for convenience
-pub use disentangle_zkp::{AccountStateLeaf, AccountMerkleTree, ReputationProver, ReputationBucket};
+pub use disentangle_zkp::{
+    AccountMerkleTree, AccountStateLeaf, ReputationBucket, ReputationProver,
+};
 
 pub type NodeId = Hash256;
 
@@ -228,12 +230,11 @@ pub fn compute_topological_mass_verified(
 
 /// Verify a single reputation claim against a verification context.
 /// Useful for pre-validation before adding transactions to the DAG.
-pub fn verify_reputation_claim(
-    claim: &ReputationClaim,
-    ctx: &VerificationContext,
-) -> bool {
+pub fn verify_reputation_claim(claim: &ReputationClaim, ctx: &VerificationContext) -> bool {
     let verifier = ReputationVerifier::new();
-    verifier.verify(claim, &ctx.expected_root, ctx.current_epoch).is_ok()
+    verifier
+        .verify(claim, &ctx.expected_root, ctx.current_epoch)
+        .is_ok()
 }
 
 fn integer_log1p(x: i32) -> FixedPoint {
@@ -346,9 +347,9 @@ pub fn verify_confidential_balance(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use disentangle_dag::Transaction;
     use disentangle_crypto::signature::generate_keypair;
-    use disentangle_crypto::types::{Nullifier, Epoch};
+    use disentangle_crypto::types::{Epoch, Nullifier};
+    use disentangle_dag::Transaction;
     use disentangle_simhash::SimHash;
     use disentangle_zkp::{AccountStateLeaf, ReputationProver};
 
@@ -362,9 +363,10 @@ mod tests {
     fn make_test_tx(depth_seed: u64, parents: Vec<NodeId>, reputation: u64) -> Transaction {
         let (sk, pk) = generate_keypair();
         let history_root = [depth_seed as u8; 32];
-        let parent_hashes: Vec<Hash256> = parents.iter().copied().collect();
+        let parent_hashes: Vec<Hash256> = parents.to_vec();
         let simhash = SimHash::from_structural(&parent_hashes, &history_root);
-        let nullifier = Nullifier::compute(&[depth_seed as u8; 32], Epoch(0), &depth_seed.to_le_bytes());
+        let nullifier =
+            Nullifier::compute(&[depth_seed as u8; 32], Epoch(0), &depth_seed.to_le_bytes());
         let mut tx = Transaction {
             id: [0u8; 32],
             ephemeral_pk: pk,
@@ -462,9 +464,7 @@ mod tests {
     fn test_verified_mass_wrong_epoch() {
         let mut dag = TransactionDAG::new();
 
-        let accounts = vec![
-            AccountStateLeaf::new([1u8; 32], 100, 10, 0),
-        ];
+        let accounts = vec![AccountStateLeaf::new([1u8; 32], 100, 10, 0)];
         let prover = ReputationProver::new(&accounts);
         let merkle_root = prover.merkle_root();
 
@@ -490,9 +490,7 @@ mod tests {
     fn test_verified_mass_wrong_root() {
         let mut dag = TransactionDAG::new();
 
-        let accounts = vec![
-            AccountStateLeaf::new([1u8; 32], 100, 10, 0),
-        ];
+        let accounts = vec![AccountStateLeaf::new([1u8; 32], 100, 10, 0)];
         let prover = ReputationProver::new(&accounts);
 
         let genesis = make_test_tx(0, vec![], 100);
@@ -529,9 +527,7 @@ mod tests {
     fn test_strict_mode_invalid_proof() {
         let mut dag = TransactionDAG::new();
 
-        let accounts = vec![
-            AccountStateLeaf::new([1u8; 32], 100, 10, 0),
-        ];
+        let accounts = vec![AccountStateLeaf::new([1u8; 32], 100, 10, 0)];
         let prover = ReputationProver::new(&accounts);
 
         let genesis = make_test_tx(0, vec![], 100);
@@ -546,14 +542,15 @@ mod tests {
         proofs.insert(gid, claim);
 
         let result = compute_topological_mass_verified(&mut dag, &gid, 0, &ctx, &proofs);
-        assert!(matches!(result, Err(ConsensusError::VerificationFailed { .. })));
+        assert!(matches!(
+            result,
+            Err(ConsensusError::VerificationFailed { .. })
+        ));
     }
 
     #[test]
     fn test_verify_reputation_claim_helper() {
-        let accounts = vec![
-            AccountStateLeaf::new([1u8; 32], 100, 10, 0),
-        ];
+        let accounts = vec![AccountStateLeaf::new([1u8; 32], 100, 10, 0)];
         let prover = ReputationProver::new(&accounts);
         let merkle_root = prover.merkle_root();
 
@@ -639,8 +636,10 @@ mod tests {
         let (winner, mass_a, mass_b) = resolve_conflict(&mut dag, &branch_a_id, &branch_b_id, 1);
 
         // Verify masses are equal (or very close due to fixed-point rounding)
-        assert_eq!(mass_a.total_mass, mass_b.total_mass,
-            "Masses should be equal for identical transactions");
+        assert_eq!(
+            mass_a.total_mass, mass_b.total_mass,
+            "Masses should be equal for identical transactions"
+        );
 
         // Tiebreaker should use lexicographic comparison of node IDs
         let expected_winner = if branch_a_id < branch_b_id {
@@ -649,8 +648,10 @@ mod tests {
             ConflictWinner::BranchB
         };
 
-        assert_eq!(winner, expected_winner,
-            "Winner should be determined by lexicographic NodeId comparison when masses are equal");
+        assert_eq!(
+            winner, expected_winner,
+            "Winner should be determined by lexicographic NodeId comparison when masses are equal"
+        );
 
         // Verify determinism: calling again should produce same result
         let (winner2, _, _) = resolve_conflict(&mut dag, &branch_a_id, &branch_b_id, 1);
@@ -677,8 +678,10 @@ mod tests {
         dag.insert_genesis(branch_b);
 
         // Initially, neither branch should be finalized (equal mass)
-        assert!(!is_finalized(&mut dag, &branch_a_id, &[branch_b_id], 1),
-            "Branch A should not be finalized with equal mass");
+        assert!(
+            !is_finalized(&mut dag, &branch_a_id, &[branch_b_id], 1),
+            "Branch A should not be finalized with equal mass"
+        );
 
         // Build descendants on branch A to increase its mass
         let mut current_parent = branch_a_id;
@@ -689,12 +692,16 @@ mod tests {
         }
 
         // Now branch A should have much more mass and be finalized
-        assert!(is_finalized(&mut dag, &branch_a_id, &[branch_b_id], 1),
-            "Branch A should be finalized with 10+ descendants vs 1 competitor");
+        assert!(
+            is_finalized(&mut dag, &branch_a_id, &[branch_b_id], 1),
+            "Branch A should be finalized with 10+ descendants vs 1 competitor"
+        );
 
         // Branch B should NOT be finalized
-        assert!(!is_finalized(&mut dag, &branch_b_id, &[branch_a_id], 1),
-            "Branch B should not be finalized when competitor has much more mass");
+        assert!(
+            !is_finalized(&mut dag, &branch_b_id, &[branch_a_id], 1),
+            "Branch B should not be finalized when competitor has much more mass"
+        );
     }
 
     #[test]
@@ -767,7 +774,10 @@ mod tests {
 
         // Test that it's deterministic
         let curv_c_a_2 = compute_curvature(&dag, &cid, &aid);
-        assert_eq!(curv_c_a, curv_c_a_2, "Curvature computation must be deterministic");
+        assert_eq!(
+            curv_c_a, curv_c_a_2,
+            "Curvature computation must be deterministic"
+        );
     }
 
     #[test]
@@ -780,7 +790,11 @@ mod tests {
         assert_eq!(integer_log1p(-100), 0, "log1p(negative) should be 0");
 
         // Test small positive values
-        assert_eq!(integer_log1p(1), SCALE / 4, "log1p(1) should return SCALE/4");
+        assert_eq!(
+            integer_log1p(1),
+            SCALE / 4,
+            "log1p(1) should return SCALE/4"
+        );
 
         // Test that function is monotonically increasing for positive inputs
         let log_10 = integer_log1p(10);
@@ -863,9 +877,18 @@ mod tests {
         let mass_post = compute_topological_mass(&mut dag, &post_id, 7000);
 
         // All should produce valid mass values
-        assert!(mass_early.total_mass > 0, "Early bootstrap should produce valid mass");
-        assert!(mass_mid.total_mass > 0, "Mid bootstrap should produce valid mass");
-        assert!(mass_post.total_mass > 0, "Post bootstrap should produce valid mass");
+        assert!(
+            mass_early.total_mass > 0,
+            "Early bootstrap should produce valid mass"
+        );
+        assert!(
+            mass_mid.total_mass > 0,
+            "Mid bootstrap should produce valid mass"
+        );
+        assert!(
+            mass_post.total_mass > 0,
+            "Post bootstrap should produce valid mass"
+        );
 
         // The actual ramping effect is tested indirectly through the integration test
         // This test just verifies that the fork_block parameter is accepted and doesn't break anything
@@ -900,10 +923,15 @@ mod tests {
         let (winner, mass_a, mass_b) = resolve_conflict(&mut dag, &aid, &bid, 1);
 
         // Branch B should have more mass due to descendants
-        assert!(mass_b.total_mass > mass_a.total_mass,
-            "Branch with more descendants should have higher mass");
-        assert_eq!(winner, ConflictWinner::BranchB,
-            "Branch with higher mass should win");
+        assert!(
+            mass_b.total_mass > mass_a.total_mass,
+            "Branch with more descendants should have higher mass"
+        );
+        assert_eq!(
+            winner,
+            ConflictWinner::BranchB,
+            "Branch with higher mass should win"
+        );
     }
 
     #[test]
@@ -936,7 +964,9 @@ mod tests {
 
         // The actual value depends on implementation, but it should be
         // less than a highly connected triangle
-        assert!(curv < SCALE,
-            "Bridge between disjoint clusters should have lower curvature than fully connected");
+        assert!(
+            curv < SCALE,
+            "Bridge between disjoint clusters should have lower curvature than fully connected"
+        );
     }
 }

--- a/disentangle-consensus/tests/integration_test.rs
+++ b/disentangle-consensus/tests/integration_test.rs
@@ -3,14 +3,14 @@
 //! Replicates the Python `conflict_v2.py` scenario in Rust to verify
 //! that the integer-arithmetic implementation correctly throttles Sybils.
 
-use disentangle_dag::{TransactionDAG, Transaction, NodeId, SCALE, Hash256};
 use disentangle_consensus::{resolve_conflict, ConflictWinner};
-use disentangle_simhash::SimHash;
 use disentangle_crypto::{
-    signature::{generate_keypair, sign, SigningKey, VerifyingKey},
     hash::sha3_256,
-    types::{Nullifier, Epoch},
+    signature::{generate_keypair, sign, SigningKey, VerifyingKey},
+    types::{Epoch, Nullifier},
 };
+use disentangle_dag::{Hash256, NodeId, Transaction, TransactionDAG, SCALE};
+use disentangle_simhash::SimHash;
 
 /// Generate a test keypair with deterministic seed
 fn make_keypair(seed: &str) -> (SigningKey, VerifyingKey) {
@@ -96,7 +96,11 @@ fn test_sybil_attack_resistance() {
     // [2] Build main chain with established users
     // Using high block numbers to ensure bootstrap throttling is fully active
     const BLOCK_OFFSET: u64 = 6000; // After BOOTSTRAP_END
-    println!("[2] Building Main Chain (blocks {}-{})...", BLOCK_OFFSET + 1, BLOCK_OFFSET + 30);
+    println!(
+        "[2] Building Main Chain (blocks {}-{})...",
+        BLOCK_OFFSET + 1,
+        BLOCK_OFFSET + 30
+    );
     let mut tips = vec![genesis_id];
     let mut tx_counter = 0u64;
 
@@ -122,7 +126,10 @@ fn test_sybil_attack_resistance() {
     println!("    Main chain transactions: {}", tx_counter);
 
     // [3] Create double-spend fork
-    println!("\n[3] Creating Double-Spend Fork at block {}...", BLOCK_OFFSET + 31);
+    println!(
+        "\n[3] Creating Double-Spend Fork at block {}...",
+        BLOCK_OFFSET + 31
+    );
     let fork_point = tips[0];
 
     let branch_a_tx = make_test_tx(
@@ -145,9 +152,18 @@ fn test_sybil_attack_resistance() {
     let branch_b_root = branch_b_tx.id;
     dag.insert_genesis(branch_b_tx);
 
-    println!("    Fork point: {:02x}{:02x}{:02x}{:02x}...", fork_point[0], fork_point[1], fork_point[2], fork_point[3]);
-    println!("    Branch A (Sybil-backed): {:02x}{:02x}{:02x}{:02x}...", branch_a_root[0], branch_a_root[1], branch_a_root[2], branch_a_root[3]);
-    println!("    Branch B (Honest): {:02x}{:02x}{:02x}{:02x}...", branch_b_root[0], branch_b_root[1], branch_b_root[2], branch_b_root[3]);
+    println!(
+        "    Fork point: {:02x}{:02x}{:02x}{:02x}...",
+        fork_point[0], fork_point[1], fork_point[2], fork_point[3]
+    );
+    println!(
+        "    Branch A (Sybil-backed): {:02x}{:02x}{:02x}{:02x}...",
+        branch_a_root[0], branch_a_root[1], branch_a_root[2], branch_a_root[3]
+    );
+    println!(
+        "    Branch B (Honest): {:02x}{:02x}{:02x}{:02x}...",
+        branch_b_root[0], branch_b_root[1], branch_b_root[2], branch_b_root[3]
+    );
 
     // [4] THE ATTACK: Sybil cluster attached via single bridge
     println!("\n[4] THE ATTACK: Attaching 5 Sybils to Branch A via single bridge...");
@@ -178,7 +194,10 @@ fn test_sybil_attack_resistance() {
         }
     }
     println!("    Sybil transactions added: 5 (1 bridge + 4 sybil)");
-    println!("    Bridge node: {:02x}{:02x}{:02x}{:02x}...", bridge_id[0], bridge_id[1], bridge_id[2], bridge_id[3]);
+    println!(
+        "    Bridge node: {:02x}{:02x}{:02x}{:02x}...",
+        bridge_id[0], bridge_id[1], bridge_id[2], bridge_id[3]
+    );
 
     // [5] THE DEFENSE: Honest transactions on Branch B with good connectivity
     println!("\n[5] THE DEFENSE: Attaching 15 Honest transactions to Branch B...");
@@ -201,7 +220,13 @@ fn test_sybil_attack_resistance() {
         // Established users have high reputation
         let reputation = 100 + ((32 + i as u64) * 10);
 
-        let tx = make_test_tx(&name, &established_keypairs[user_idx], parents, BLOCK_OFFSET + 32 + i as u64, reputation);
+        let tx = make_test_tx(
+            &name,
+            &established_keypairs[user_idx],
+            parents,
+            BLOCK_OFFSET + 32 + i as u64,
+            reputation,
+        );
         let tx_id = tx.id;
         dag.insert_genesis(tx);
 
@@ -215,7 +240,10 @@ fn test_sybil_attack_resistance() {
     let bridge_curv = dag.discrete_curvature(&branch_a_root, &bridge_id);
     let bridge_curv_float = bridge_curv as f64 / SCALE as f64;
     println!("    Bridge edge curvature (raw): {}", bridge_curv);
-    println!("    Bridge edge curvature (scaled): {:.4}", bridge_curv_float);
+    println!(
+        "    Bridge edge curvature (scaled): {:.4}",
+        bridge_curv_float
+    );
 
     let bridge_weight = dag.curvature_weight(bridge_curv);
     let bridge_weight_float = bridge_weight as f64 / SCALE as f64;
@@ -224,7 +252,8 @@ fn test_sybil_attack_resistance() {
     // [7] Resolve conflict
     println!("\n[7] Resolving Conflict...");
     let fork_block = BLOCK_OFFSET + 31;
-    let (winner, mass_a, mass_b) = resolve_conflict(&mut dag, &branch_a_root, &branch_b_root, fork_block);
+    let (winner, mass_a, mass_b) =
+        resolve_conflict(&mut dag, &branch_a_root, &branch_b_root, fork_block);
 
     let mass_a_float = mass_a.total_mass as f64 / SCALE as f64;
     let mass_b_float = mass_b.total_mass as f64 / SCALE as f64;
@@ -237,15 +266,27 @@ fn test_sybil_attack_resistance() {
     println!("      Transactions: 6 (branch root + 1 bridge + 4 sybils)");
     println!("      Supporters: {}", mass_a.supporters);
     println!("      Claimed Reputation: {}", mass_a.claimed_reputation);
-    println!("      Diversity Score: {:.2}", mass_a.diversity_score as f64 / SCALE as f64);
-    println!("      Total Mass: {} (scaled: {:.2})", mass_a.total_mass, mass_a_float);
+    println!(
+        "      Diversity Score: {:.2}",
+        mass_a.diversity_score as f64 / SCALE as f64
+    );
+    println!(
+        "      Total Mass: {} (scaled: {:.2})",
+        mass_a.total_mass, mass_a_float
+    );
 
     println!("\n    BRANCH B (Honest):");
     println!("      Transactions: 16 (root + 15 honest)");
     println!("      Supporters: {}", mass_b.supporters);
     println!("      Claimed Reputation: {}", mass_b.claimed_reputation);
-    println!("      Diversity Score: {:.2}", mass_b.diversity_score as f64 / SCALE as f64);
-    println!("      Total Mass: {} (scaled: {:.2})", mass_b.total_mass, mass_b_float);
+    println!(
+        "      Diversity Score: {:.2}",
+        mass_b.diversity_score as f64 / SCALE as f64
+    );
+    println!(
+        "      Total Mass: {} (scaled: {:.2})",
+        mass_b.total_mass, mass_b_float
+    );
 
     let winner_str = match winner {
         ConflictWinner::BranchA => "BRANCH A (Sybil) - ATTACK SUCCEEDED!",
@@ -255,7 +296,10 @@ fn test_sybil_attack_resistance() {
 
     if mass_b.total_mass > 0 {
         let ratio = mass_a.total_mass as f64 / mass_b.total_mass as f64;
-        println!("    Sybil effectiveness: {:.1}% of honest mass", ratio * 100.0);
+        println!(
+            "    Sybil effectiveness: {:.1}% of honest mass",
+            ratio * 100.0
+        );
     }
 
     println!("\n======================================================================\n");
@@ -263,7 +307,10 @@ fn test_sybil_attack_resistance() {
     // The test passes if honest branch wins
     // With v0.2, sybils have 0 reputation and pass through a bottleneck bridge
     assert_eq!(winner, ConflictWinner::BranchB, "Honest branch should win!");
-    assert!(mass_b.total_mass > mass_a.total_mass, "Honest mass should exceed Sybil mass");
+    assert!(
+        mass_b.total_mass > mass_a.total_mass,
+        "Honest mass should exceed Sybil mass"
+    );
 
     println!("TEST PASSED: Sybil attack successfully defeated!\n");
 }
@@ -328,12 +375,24 @@ fn test_bootstrap_ramping_conflict_resolution() {
     let alpha_mid = effective_alpha(mid_block);
     let alpha_post = effective_alpha(post_block);
 
-    println!("    Mid-ramp block {}: alpha = {} (max = {})", mid_block, alpha_mid, ALPHA_MAX);
-    println!("    Post-ramp block {}: alpha = {} (max = {})", post_block, alpha_post, ALPHA_MAX);
+    println!(
+        "    Mid-ramp block {}: alpha = {} (max = {})",
+        mid_block, alpha_mid, ALPHA_MAX
+    );
+    println!(
+        "    Post-ramp block {}: alpha = {} (max = {})",
+        post_block, alpha_post, ALPHA_MAX
+    );
 
     assert!(alpha_mid > 0, "Mid-ramp alpha should be > 0");
-    assert!(alpha_mid < ALPHA_MAX, "Mid-ramp alpha should be < ALPHA_MAX");
-    assert_eq!(alpha_post, ALPHA_MAX, "Post-ramp alpha should equal ALPHA_MAX");
+    assert!(
+        alpha_mid < ALPHA_MAX,
+        "Mid-ramp alpha should be < ALPHA_MAX"
+    );
+    assert_eq!(
+        alpha_post, ALPHA_MAX,
+        "Post-ramp alpha should equal ALPHA_MAX"
+    );
 
     // Helper: build a conflict scenario at the given block offset and return
     // (branch_a_mass, branch_b_mass) where branch_a goes through a bottleneck bridge.
@@ -441,15 +500,22 @@ fn test_bootstrap_ramping_conflict_resolution() {
         }
 
         let fork_block = base_block;
-        let (_, mass_a, mass_b) = resolve_conflict(&mut dag, &branch_a_id, &branch_b_id, fork_block);
+        let (_, mass_a, mass_b) =
+            resolve_conflict(&mut dag, &branch_a_id, &branch_b_id, fork_block);
         (mass_a.total_mass, mass_b.total_mass)
     }
 
     let (mass_a_mid, mass_b_mid) = build_conflict_at_block(mid_block);
     let (mass_a_post, mass_b_post) = build_conflict_at_block(post_block);
 
-    println!("\n    Mid-ramp (block {}): branch A = {}, branch B = {}", mid_block, mass_a_mid, mass_b_mid);
-    println!("    Post-ramp (block {}): branch A = {}, branch B = {}", post_block, mass_a_post, mass_b_post);
+    println!(
+        "\n    Mid-ramp (block {}): branch A = {}, branch B = {}",
+        mid_block, mass_a_mid, mass_b_mid
+    );
+    println!(
+        "    Post-ramp (block {}): branch A = {}, branch B = {}",
+        post_block, mass_a_post, mass_b_post
+    );
 
     // Key invariant: the sybil branch (A) should be more heavily throttled
     // in the post-ramp scenario than in the mid-ramp scenario.
@@ -470,27 +536,41 @@ fn test_bootstrap_ramping_conflict_resolution() {
     println!("    Post-ramp A/B ratio: {:.4}", ratio_post);
 
     // Key invariant 1: the effective_alpha is correctly graduated
-    assert!(alpha_mid < alpha_post,
+    assert!(
+        alpha_mid < alpha_post,
         "Mid-ramp alpha ({}) should be strictly less than post-ramp alpha ({})",
-        alpha_mid, alpha_post);
+        alpha_mid,
+        alpha_post
+    );
 
     // Key invariant 2: different alpha values should produce different mass values.
     // The mid-ramp and post-ramp scenarios have identical DAG structure but different
     // throttling levels, so the computed masses should differ.
-    assert!(mass_a_mid != mass_a_post || mass_b_mid != mass_b_post,
+    assert!(
+        mass_a_mid != mass_a_post || mass_b_mid != mass_b_post,
         "Different alpha values should produce different mass computations. \
          Mid: A={}, B={}. Post: A={}, B={}.",
-        mass_a_mid, mass_b_mid, mass_a_post, mass_b_post);
+        mass_a_mid,
+        mass_b_mid,
+        mass_a_post,
+        mass_b_post
+    );
 
     // Key invariant 3: in both scenarios, the well-connected honest branch (B)
     // should dominate the sybil branch (A). Throttling hurts sybils but the
     // curvature-based weighting ensures honest branches always win.
-    assert!(mass_b_mid > mass_a_mid,
+    assert!(
+        mass_b_mid > mass_a_mid,
         "Mid-ramp: honest branch B ({}) should beat sybil branch A ({})",
-        mass_b_mid, mass_a_mid);
-    assert!(mass_b_post > mass_a_post,
+        mass_b_mid,
+        mass_a_mid
+    );
+    assert!(
+        mass_b_post > mass_a_post,
         "Post-ramp: honest branch B ({}) should beat sybil branch A ({})",
-        mass_b_post, mass_a_post);
+        mass_b_post,
+        mass_a_post
+    );
 
     println!("\nTEST PASSED: Bootstrap ramping modulates conflict resolution correctly\n");
 }
@@ -536,10 +616,16 @@ fn test_is_finalized() {
     // Initially, neither branch should be finalized against the other because
     // they have similar mass (both have a single transaction root).
     let finalized_early = is_finalized(&mut dag, &branch_a_id, &[branch_b_id], fork_block + 1);
-    println!("    After fork (equal branches): is_finalized = {}", finalized_early);
+    println!(
+        "    After fork (equal branches): is_finalized = {}",
+        finalized_early
+    );
     // Both branches are trivially similar in mass -- neither is 10x the other
     // so finalization should be false for A vs B.
-    assert!(!finalized_early, "Branch should NOT be finalized when competitor has comparable mass");
+    assert!(
+        !finalized_early,
+        "Branch should NOT be finalized when competitor has comparable mass"
+    );
 
     // Now build up Branch A significantly with many high-reputation honest txs
     let mut tips_a = vec![branch_a_id];
@@ -564,13 +650,25 @@ fn test_is_finalized() {
     // Branch A now has 20+ high-reputation supporters with good connectivity.
     // Branch B still has only 1 transaction with low reputation.
     let finalized_after = is_finalized(&mut dag, &branch_a_id, &[branch_b_id], fork_block + 1);
-    println!("    After building Branch A (20 txs, high rep): is_finalized = {}", finalized_after);
-    assert!(finalized_after, "Branch A should be finalized with 10x+ mass advantage over Branch B");
+    println!(
+        "    After building Branch A (20 txs, high rep): is_finalized = {}",
+        finalized_after
+    );
+    assert!(
+        finalized_after,
+        "Branch A should be finalized with 10x+ mass advantage over Branch B"
+    );
 
     // Verify the reverse: Branch B should NOT be finalized against Branch A
     let finalized_b = is_finalized(&mut dag, &branch_b_id, &[branch_a_id], fork_block + 1);
-    println!("    Branch B against Branch A: is_finalized = {}", finalized_b);
-    assert!(!finalized_b, "Branch B should NOT be finalized against the dominant Branch A");
+    println!(
+        "    Branch B against Branch A: is_finalized = {}",
+        finalized_b
+    );
+    assert!(
+        !finalized_b,
+        "Branch B should NOT be finalized against the dominant Branch A"
+    );
 
     println!("\nTEST PASSED: is_finalized correctly tracks finality threshold\n");
 }

--- a/disentangle-crypto/src/hash.rs
+++ b/disentangle-crypto/src/hash.rs
@@ -11,8 +11,8 @@
 //! - SimHash seed derivation
 //! - Nullifier computation
 
-use sha3::{Sha3_256, Digest};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
+use sha3::{Digest, Sha3_256};
 
 pub const HASH_BYTES: usize = 32;
 

--- a/disentangle-crypto/src/kem.rs
+++ b/disentangle-crypto/src/kem.rs
@@ -11,10 +11,13 @@
 //! - Stealth addresses (encrypting outputs to receivers)
 //! - Hybrid key exchange in P2P transport (future)
 
-use pqcrypto_kyber::kyber1024;
-use pqcrypto_traits::kem::{PublicKey as PqPublicKey, SecretKey as PqSecretKey, Ciphertext as PqCiphertext, SharedSecret as PqSharedSecret};
-use serde::{Serialize, Deserialize, Serializer, Deserializer};
 use crate::{CryptoError, Result};
+use pqcrypto_kyber::kyber1024;
+use pqcrypto_traits::kem::{
+    Ciphertext as PqCiphertext, PublicKey as PqPublicKey, SecretKey as PqSecretKey,
+    SharedSecret as PqSharedSecret,
+};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub const ENCAPSULATION_KEY_BYTES: usize = 1568;
 pub const DECAPSULATION_KEY_BYTES: usize = 3168;
@@ -57,8 +60,8 @@ impl EncapsulationKey {
                 got: bytes.len(),
             });
         }
-        let pk = kyber1024::PublicKey::from_bytes(bytes)
-            .map_err(|_| CryptoError::InvalidKeyLength {
+        let pk =
+            kyber1024::PublicKey::from_bytes(bytes).map_err(|_| CryptoError::InvalidKeyLength {
                 expected: ENCAPSULATION_KEY_BYTES,
                 got: bytes.len(),
             })?;
@@ -78,8 +81,8 @@ impl DecapsulationKey {
                 got: bytes.len(),
             });
         }
-        let sk = kyber1024::SecretKey::from_bytes(bytes)
-            .map_err(|_| CryptoError::InvalidKeyLength {
+        let sk =
+            kyber1024::SecretKey::from_bytes(bytes).map_err(|_| CryptoError::InvalidKeyLength {
                 expected: DECAPSULATION_KEY_BYTES,
                 got: bytes.len(),
             })?;
@@ -99,11 +102,12 @@ impl Ciphertext {
                 got: bytes.len(),
             });
         }
-        let ct = kyber1024::Ciphertext::from_bytes(bytes)
-            .map_err(|_| CryptoError::InvalidKeyLength {
+        let ct = kyber1024::Ciphertext::from_bytes(bytes).map_err(|_| {
+            CryptoError::InvalidKeyLength {
                 expected: CIPHERTEXT_BYTES,
                 got: bytes.len(),
-            })?;
+            }
+        })?;
         Ok(Self(ct))
     }
 
@@ -130,7 +134,10 @@ pub fn encapsulate(encapsulation_key: &EncapsulationKey) -> (Ciphertext, SharedS
     (Ciphertext(ct), SharedSecret(secret))
 }
 
-pub fn decapsulate(decapsulation_key: &DecapsulationKey, ciphertext: &Ciphertext) -> Result<SharedSecret> {
+pub fn decapsulate(
+    decapsulation_key: &DecapsulationKey,
+    ciphertext: &Ciphertext,
+) -> Result<SharedSecret> {
     let ss = kyber1024::decapsulate(&ciphertext.0, &decapsulation_key.0);
     let mut secret = [0u8; SHARED_SECRET_BYTES];
     secret.copy_from_slice(ss.as_bytes());
@@ -187,7 +194,9 @@ impl std::fmt::Debug for EncapsulationKey {
 
 impl std::fmt::Debug for DecapsulationKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DecapsulationKey").field("bytes", &"[REDACTED]").finish()
+        f.debug_struct("DecapsulationKey")
+            .field("bytes", &"[REDACTED]")
+            .finish()
     }
 }
 
@@ -203,7 +212,9 @@ impl std::fmt::Debug for Ciphertext {
 
 impl std::fmt::Debug for SharedSecret {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SharedSecret").field("bytes", &"[REDACTED]").finish()
+        f.debug_struct("SharedSecret")
+            .field("bytes", &"[REDACTED]")
+            .finish()
     }
 }
 

--- a/disentangle-crypto/src/lib.rs
+++ b/disentangle-crypto/src/lib.rs
@@ -12,15 +12,18 @@
 //!
 //! All primitives are quantum-resistant and deterministic.
 
-pub mod signature;
-pub mod kem;
 pub mod hash;
+pub mod kem;
+pub mod signature;
 pub mod types;
 
-pub use signature::{SigningKey, VerifyingKey, Signature, sign, verify, generate_keypair};
-pub use kem::{EncapsulationKey, DecapsulationKey, Ciphertext, SharedSecret, encapsulate, decapsulate, generate_kem_keypair};
 pub use hash::{sha3_256, sha3_256_multi, Hash256};
-pub use types::{PublicKey, SecretKey, NodeId};
+pub use kem::{
+    decapsulate, encapsulate, generate_kem_keypair, Ciphertext, DecapsulationKey, EncapsulationKey,
+    SharedSecret,
+};
+pub use signature::{generate_keypair, sign, verify, Signature, SigningKey, VerifyingKey};
+pub use types::{NodeId, PublicKey, SecretKey};
 
 #[derive(Debug, thiserror::Error)]
 pub enum CryptoError {

--- a/disentangle-crypto/src/signature.rs
+++ b/disentangle-crypto/src/signature.rs
@@ -6,10 +6,12 @@
 //! - Signature: 4,627 bytes
 //! - Security: NIST Level 5 (equivalent to AES-256)
 
-use pqcrypto_dilithium::dilithium5;
-use pqcrypto_traits::sign::{PublicKey as PqPublicKey, SecretKey as PqSecretKey, DetachedSignature};
-use serde::{Serialize, Deserialize, Serializer, Deserializer};
 use crate::{CryptoError, Result};
+use pqcrypto_dilithium::dilithium5;
+use pqcrypto_traits::sign::{
+    DetachedSignature, PublicKey as PqPublicKey, SecretKey as PqSecretKey,
+};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub const PUBLIC_KEY_BYTES: usize = 2592;
 pub const SECRET_KEY_BYTES: usize = 4896;
@@ -54,11 +56,12 @@ impl SigningKey {
                 got: bytes.len(),
             });
         }
-        let sk = dilithium5::SecretKey::from_bytes(bytes)
-            .map_err(|_| CryptoError::InvalidKeyLength {
+        let sk = dilithium5::SecretKey::from_bytes(bytes).map_err(|_| {
+            CryptoError::InvalidKeyLength {
                 expected: SECRET_KEY_BYTES,
                 got: bytes.len(),
-            })?;
+            }
+        })?;
         Ok(Self(sk))
     }
 
@@ -75,11 +78,12 @@ impl VerifyingKey {
                 got: bytes.len(),
             });
         }
-        let pk = dilithium5::PublicKey::from_bytes(bytes)
-            .map_err(|_| CryptoError::InvalidKeyLength {
+        let pk = dilithium5::PublicKey::from_bytes(bytes).map_err(|_| {
+            CryptoError::InvalidKeyLength {
                 expected: PUBLIC_KEY_BYTES,
                 got: bytes.len(),
-            })?;
+            }
+        })?;
         Ok(Self(pk))
     }
 
@@ -161,7 +165,9 @@ impl<'de> Deserialize<'de> for Signature {
 
 impl std::fmt::Debug for SigningKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SigningKey").field("bytes", &"[REDACTED]").finish()
+        f.debug_struct("SigningKey")
+            .field("bytes", &"[REDACTED]")
+            .finish()
     }
 }
 

--- a/disentangle-crypto/src/types.rs
+++ b/disentangle-crypto/src/types.rs
@@ -4,7 +4,7 @@
 
 use crate::hash::Hash256;
 use crate::signature::VerifyingKey;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 pub type NodeId = Hash256;
 pub type PublicKey = VerifyingKey;
@@ -36,7 +36,7 @@ impl AccountId {
     pub fn from_public_key(pk: &VerifyingKey) -> Self {
         Self(crate::hash::sha3_256(&pk.to_bytes()))
     }
-    
+
     pub fn as_bytes(&self) -> &Hash256 {
         &self.0
     }
@@ -54,11 +54,11 @@ pub struct ReputationScore(pub u64);
 impl ReputationScore {
     pub const ZERO: Self = Self(0);
     pub const MIN_VOUCH_REQUIRED: Self = Self(50);
-    
+
     pub fn from_tx_count(count: u64) -> Self {
         Self(count)
     }
-    
+
     pub fn as_u64(&self) -> u64 {
         self.0
     }
@@ -69,9 +69,13 @@ pub struct Nullifier(pub Hash256);
 
 impl Nullifier {
     pub fn compute(secret_key_hash: &Hash256, epoch: Epoch, tx_nonce: &[u8]) -> Self {
-        Self(crate::hash::compute_nullifier(secret_key_hash, epoch.0, tx_nonce))
+        Self(crate::hash::compute_nullifier(
+            secret_key_hash,
+            epoch.0,
+            tx_nonce,
+        ))
     }
-    
+
     pub fn as_bytes(&self) -> &Hash256 {
         &self.0
     }
@@ -80,8 +84,8 @@ impl Nullifier {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::signature::generate_keypair;
     use crate::hash::HASH_BYTES;
+    use crate::signature::generate_keypair;
 
     #[test]
     fn test_epoch_from_depth() {

--- a/disentangle-dag/src/lib.rs
+++ b/disentangle-dag/src/lib.rs
@@ -9,16 +9,16 @@
 //! - Added EphemeralIdentity for privacy
 //! - SimHash now structurally bound
 
-use std::collections::{HashMap, HashSet};
 use disentangle_crypto::{
-    signature::{VerifyingKey, Signature},
     hash::sha3_256_multi,
+    signature::{Signature, VerifyingKey},
 };
 use disentangle_simhash::SimHash;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 
-pub use disentangle_crypto::types::{NodeId, Nullifier, Epoch};
 pub use disentangle_crypto::hash::Hash256;
+pub use disentangle_crypto::types::{Epoch, NodeId, Nullifier};
 
 pub const SCALE: i32 = 65536;
 pub type FixedPoint = i32;
@@ -110,15 +110,13 @@ impl Transaction {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[derive(Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AccountState {
     pub history_root: Hash256,
     pub transaction_count: u64,
     pub first_seen_depth: u64,
     pub reputation_score: u64,
 }
-
 
 #[derive(Debug, Default)]
 pub struct TransactionDAG {
@@ -155,7 +153,7 @@ impl TransactionDAG {
         self.transactions.insert(id, tx);
         Ok(())
     }
-    
+
     /// Insert a transaction without parent validation.
     /// Used for genesis and test scenarios. Still builds children index.
     pub fn insert_genesis(&mut self, tx: Transaction) {
@@ -173,11 +171,11 @@ impl TransactionDAG {
     pub fn get(&self, id: &NodeId) -> Option<&Transaction> {
         self.transactions.get(id)
     }
-    
+
     pub fn contains(&self, id: &NodeId) -> bool {
         self.transactions.contains_key(id)
     }
-    
+
     pub fn has_nullifier(&self, nullifier: &Nullifier) -> bool {
         self.nullifier_set.contains(nullifier)
     }
@@ -395,15 +393,15 @@ impl TransactionDAG {
     pub fn transaction_ids(&self) -> impl Iterator<Item = &NodeId> {
         self.transactions.keys()
     }
-    
+
     pub fn len(&self) -> usize {
         self.transactions.len()
     }
-    
+
     pub fn is_empty(&self) -> bool {
         self.transactions.is_empty()
     }
-    
+
     pub fn clear_curvature_cache(&mut self) {
         self.curvature_cache.clear();
     }
@@ -456,7 +454,9 @@ impl TransactionDAG {
             }
             let d = match self.transactions.get(&node) {
                 Some(tx) if !tx.parents.is_empty() => {
-                    1 + tx.parents.iter()
+                    1 + tx
+                        .parents
+                        .iter()
                         .map(|p| self.depth_cache.get(p).copied().unwrap_or(0))
                         .max()
                         .unwrap_or(0)
@@ -487,7 +487,8 @@ impl TransactionDAG {
         if parents.is_empty() {
             return 0;
         }
-        1 + parents.iter()
+        1 + parents
+            .iter()
             .filter_map(|p| self.cached_depth(p))
             .max()
             .unwrap_or(0)
@@ -516,7 +517,7 @@ mod tests {
     fn make_test_tx(nonce_seed: u64, parents: Vec<NodeId>) -> Transaction {
         let (sk, pk) = generate_keypair();
         let history_root = [nonce_seed as u8; 32];
-        let parent_hashes: Vec<Hash256> = parents.iter().copied().collect();
+        let parent_hashes: Vec<Hash256> = parents.to_vec();
         let simhash = SimHash::from_structural(&parent_hashes, &history_root);
         let nullifier = Nullifier::compute(&[0u8; 32], Epoch(0), &nonce_seed.to_le_bytes());
         let mut tx = Transaction {
@@ -549,7 +550,10 @@ mod tests {
         dag.insert_genesis(genesis.clone());
         let mut duplicate = genesis.clone();
         duplicate.id = [1u8; 32];
-        assert!(matches!(dag.insert(duplicate), Err(DagError::DuplicateNullifier)));
+        assert!(matches!(
+            dag.insert(duplicate),
+            Err(DagError::DuplicateNullifier)
+        ));
     }
 
     #[test]
@@ -589,7 +593,10 @@ mod tests {
         // Midpoint: half throttling
         let midpoint = (BOOTSTRAP_START + BOOTSTRAP_END) / 2;
         let mid_alpha = effective_alpha(midpoint);
-        assert!(mid_alpha > 0 && mid_alpha < ALPHA_MAX, "Mid-bootstrap alpha should be between 0 and max");
+        assert!(
+            mid_alpha > 0 && mid_alpha < ALPHA_MAX,
+            "Mid-bootstrap alpha should be between 0 and max"
+        );
 
         // At bootstrap end: full throttling
         assert_eq!(effective_alpha(BOOTSTRAP_END), ALPHA_MAX);
@@ -602,20 +609,29 @@ mod tests {
         let dag = TransactionDAG::new();
 
         // Negative curvature (bridge edge)
-        let negative_curv = -SCALE / 2;  // -0.5 in fixed point
+        let negative_curv = -SCALE / 2; // -0.5 in fixed point
 
         // During bootstrap: no throttling, weight = SCALE
         let weight_early = dag.curvature_weight_at_depth(negative_curv, 500);
-        assert_eq!(weight_early, SCALE, "Early bootstrap should have no throttling");
+        assert_eq!(
+            weight_early, SCALE,
+            "Early bootstrap should have no throttling"
+        );
 
         // After full activation: throttled to minimum
         let weight_late = dag.curvature_weight_at_depth(negative_curv, 10_000);
-        assert_eq!(weight_late, MIN_CURVATURE_WEIGHT, "Full throttling should clamp to minimum");
+        assert_eq!(
+            weight_late, MIN_CURVATURE_WEIGHT,
+            "Full throttling should clamp to minimum"
+        );
 
         // Positive curvature should always give full weight
-        let positive_curv = SCALE / 4;  // +0.25
+        let positive_curv = SCALE / 4; // +0.25
         let weight_pos = dag.curvature_weight_at_depth(positive_curv, 10_000);
-        assert_eq!(weight_pos, SCALE, "Positive curvature should have full weight");
+        assert_eq!(
+            weight_pos, SCALE,
+            "Positive curvature should have full weight"
+        );
     }
 
     #[test]
@@ -641,11 +657,17 @@ mod tests {
         // Curvature is immutable by construction (ancestor-based).
         // Once computed, it is always "frozen" (cached).
         let curv1 = dag.discrete_curvature(&gid, &tx1id);
-        assert!(dag.is_curvature_frozen(&gid, &tx1id), "Curvature should be frozen immediately after computation");
+        assert!(
+            dag.is_curvature_frozen(&gid, &tx1id),
+            "Curvature should be frozen immediately after computation"
+        );
 
         // Recomputing at a different block should return the same value
         let curv2 = dag.discrete_curvature(&gid, &tx1id);
-        assert_eq!(curv1, curv2, "Curvature is immutable — must be same regardless of block");
+        assert_eq!(
+            curv1, curv2,
+            "Curvature is immutable — must be same regardless of block"
+        );
 
         // Verify cached curvature is returned
         let curv3 = dag.discrete_curvature(&gid, &tx1id);
@@ -669,10 +691,16 @@ mod tests {
 
         // Find path weight at different block heights
         let weight_early = dag.find_best_path_weight(&gid, &tx1id, 10, 500);
-        assert!(weight_early > 0, "Path weight should be positive during bootstrap");
+        assert!(
+            weight_early > 0,
+            "Path weight should be positive during bootstrap"
+        );
 
         let weight_late = dag.find_best_path_weight(&gid, &tx1id, 10, 10_000);
-        assert!(weight_late > 0, "Path weight should be positive after bootstrap");
+        assert!(
+            weight_late > 0,
+            "Path weight should be positive after bootstrap"
+        );
     }
 
     #[test]
@@ -697,7 +725,10 @@ mod tests {
         let mut bad_tx = make_test_tx(100, parent_ids[..10].to_vec());
         bad_tx.nullifier = Nullifier::compute(&[100u8; 32], Epoch(0), b"bad");
         bad_tx.id = bad_tx.compute_id();
-        assert!(matches!(dag.insert(bad_tx), Err(DagError::TooManyParents(10, 8))));
+        assert!(matches!(
+            dag.insert(bad_tx),
+            Err(DagError::TooManyParents(10, 8))
+        ));
     }
 
     #[test]
@@ -709,7 +740,10 @@ mod tests {
         let mut bad_tx = make_test_tx(1, vec![]);
         bad_tx.nullifier = Nullifier::compute(&[1u8; 32], Epoch(0), b"empty");
         bad_tx.id = bad_tx.compute_id();
-        assert!(matches!(dag.insert(bad_tx), Err(DagError::TooFewParents(0, _))));
+        assert!(matches!(
+            dag.insert(bad_tx),
+            Err(DagError::TooFewParents(0, _))
+        ));
     }
 
     #[test]
@@ -835,8 +869,10 @@ mod tests {
         let curv_after = dag.discrete_curvature(&aid, &bid);
 
         // CRITICAL: curvature must be identical (ancestor-based = immutable)
-        assert_eq!(curv_before, curv_after,
-            "Curvature must not change when children are added (ancestor-based computation)");
+        assert_eq!(
+            curv_before, curv_after,
+            "Curvature must not change when children are added (ancestor-based computation)"
+        );
     }
 
     #[test]
@@ -895,7 +931,10 @@ mod tests {
         // Jaccard = 1/5, kappa = 2/5 - 1 = -3/5 = -0.6
         let curv_ce = dag.discrete_curvature(&cid, &eid);
         // Still negative in small DAG, but not -1.0 like pure tree
-        assert!(curv_ce > -SCALE, "Should be better than pure tree kappa=-1.0");
+        assert!(
+            curv_ce > -SCALE,
+            "Should be better than pure tree kappa=-1.0"
+        );
     }
 
     // ========================================================================
@@ -916,8 +955,10 @@ mod tests {
         tx_one_parent.id = tx_one_parent.compute_id();
 
         let result = dag.insert(tx_one_parent);
-        assert!(matches!(result, Err(DagError::TooFewParents(1, 2))),
-                "Transaction with 1 parent should be rejected (MIN_PARENTS=2)");
+        assert!(
+            matches!(result, Err(DagError::TooFewParents(1, 2))),
+            "Transaction with 1 parent should be rejected (MIN_PARENTS=2)"
+        );
     }
 
     #[test]
@@ -940,8 +981,10 @@ mod tests {
         tx_two_parents.nullifier = Nullifier::compute(&[2u8; 32], Epoch(0), b"two");
         tx_two_parents.id = tx_two_parents.compute_id();
 
-        assert!(dag.insert(tx_two_parents).is_ok(),
-                "Transaction with 2 parents should succeed (MIN_PARENTS=2)");
+        assert!(
+            dag.insert(tx_two_parents).is_ok(),
+            "Transaction with 2 parents should succeed (MIN_PARENTS=2)"
+        );
     }
 
     #[test]
@@ -968,8 +1011,10 @@ mod tests {
         tx_max.nullifier = Nullifier::compute(&[100u8; 32], Epoch(0), b"max");
         tx_max.id = tx_max.compute_id();
 
-        assert!(dag.insert(tx_max).is_ok(),
-                "Transaction with MAX_PARENTS (8) should succeed");
+        assert!(
+            dag.insert(tx_max).is_ok(),
+            "Transaction with MAX_PARENTS (8) should succeed"
+        );
     }
 
     #[test]
@@ -997,8 +1042,10 @@ mod tests {
         tx_too_many.id = tx_too_many.compute_id();
 
         let result = dag.insert(tx_too_many);
-        assert!(matches!(result, Err(DagError::TooManyParents(9, 8))),
-                "Transaction with 9 parents should be rejected (MAX_PARENTS=8)");
+        assert!(
+            matches!(result, Err(DagError::TooManyParents(9, 8))),
+            "Transaction with 9 parents should be rejected (MAX_PARENTS=8)"
+        );
     }
 
     #[test]
@@ -1020,8 +1067,10 @@ mod tests {
             confidential_outputs: vec![],
         };
 
-        assert!(tx.verify_signature(message),
-                "Valid signature should pass verification");
+        assert!(
+            tx.verify_signature(message),
+            "Valid signature should pass verification"
+        );
     }
 
     #[test]
@@ -1044,8 +1093,10 @@ mod tests {
         };
 
         let tampered_message = b"tampered message";
-        assert!(!tx.verify_signature(tampered_message),
-                "Tampered message should fail verification");
+        assert!(
+            !tx.verify_signature(tampered_message),
+            "Tampered message should fail verification"
+        );
     }
 
     #[test]
@@ -1068,8 +1119,10 @@ mod tests {
             confidential_outputs: vec![],
         };
 
-        assert!(!tx.verify_signature(message),
-                "Signature with wrong key should fail verification");
+        assert!(
+            !tx.verify_signature(message),
+            "Signature with wrong key should fail verification"
+        );
     }
 
     #[test]
@@ -1082,7 +1135,10 @@ mod tests {
 
         // Test with SCALE * SCALE (1.0 * 1.0 = 1.0)
         let result2 = fp_mul(SCALE, SCALE);
-        assert_eq!(result2, SCALE, "SCALE * SCALE should equal SCALE (1.0 * 1.0 = 1.0)");
+        assert_eq!(
+            result2, SCALE,
+            "SCALE * SCALE should equal SCALE (1.0 * 1.0 = 1.0)"
+        );
 
         // Test with large but safe values (100.0 * 2.0 = 200.0)
         let hundred = 100 * SCALE;
@@ -1119,7 +1175,11 @@ mod tests {
     #[test]
     fn test_fp_from_ratio_zero_numerator() {
         // Test with 0/0 (should return 0)
-        assert_eq!(fp_from_ratio(0, 0), 0, "0/0 should return 0 (defined behavior)");
+        assert_eq!(
+            fp_from_ratio(0, 0),
+            0,
+            "0/0 should return 0 (defined behavior)"
+        );
 
         // Test 0/nonzero
         assert_eq!(fp_from_ratio(0, 100), 0, "0/100 should return 0");
@@ -1128,7 +1188,11 @@ mod tests {
     #[test]
     fn test_fp_from_ratio_zero_denominator() {
         // Test with nonzero/0 (should return 0)
-        assert_eq!(fp_from_ratio(100, 0), 0, "100/0 should return 0 (defined behavior)");
+        assert_eq!(
+            fp_from_ratio(100, 0),
+            0,
+            "100/0 should return 0 (defined behavior)"
+        );
     }
 
     #[test]
@@ -1222,7 +1286,10 @@ mod tests {
         // ancestors(D, 2) = {B, C, A} (A appears via both paths but counted once)
         let anc2 = dag.ancestors(&did, 2);
         assert_eq!(anc2.len(), 3, "D should have 3 ancestors at depth 2");
-        assert!(anc2.contains(&aid), "Diamond pattern should include A at depth 2");
+        assert!(
+            anc2.contains(&aid),
+            "Diamond pattern should include A at depth 2"
+        );
         assert!(anc2.contains(&bid) && anc2.contains(&cid));
     }
 
@@ -1251,8 +1318,15 @@ mod tests {
 
         // neighbors(a) should include both g (parent) and b (child)
         let neighbors = dag.neighbors(&aid);
-        assert_eq!(neighbors.len(), 2, "A should have 2 neighbors (1 parent + 1 child)");
-        assert!(neighbors.contains(&gid), "Neighbors should include parent G");
+        assert_eq!(
+            neighbors.len(),
+            2,
+            "A should have 2 neighbors (1 parent + 1 child)"
+        );
+        assert!(
+            neighbors.contains(&gid),
+            "Neighbors should include parent G"
+        );
         assert!(neighbors.contains(&bid), "Neighbors should include child B");
     }
 
@@ -1265,42 +1339,57 @@ mod tests {
         // Test with very negative curvature (should clamp to MIN)
         let very_negative = -SCALE; // -1.0 (maximum negative)
         let weight_min = dag.curvature_weight_with_alpha(very_negative, ALPHA_MAX);
-        assert_eq!(weight_min, MIN_CURVATURE_WEIGHT,
-                   "Very negative curvature should clamp to MIN_CURVATURE_WEIGHT");
+        assert_eq!(
+            weight_min, MIN_CURVATURE_WEIGHT,
+            "Very negative curvature should clamp to MIN_CURVATURE_WEIGHT"
+        );
 
         // Test with positive curvature (should clamp to SCALE)
         let positive = SCALE / 2; // +0.5
         let weight_pos = dag.curvature_weight_with_alpha(positive, ALPHA_MAX);
         // With alpha=3, weight = SCALE + 3 * (SCALE/2) = SCALE + 1.5*SCALE = 2.5*SCALE
         // Should clamp to SCALE
-        assert_eq!(weight_pos, SCALE,
-                   "Positive curvature should clamp to SCALE (max weight)");
+        assert_eq!(
+            weight_pos, SCALE,
+            "Positive curvature should clamp to SCALE (max weight)"
+        );
 
         // Test with zero curvature
         let zero_curv = 0;
         let weight_zero = dag.curvature_weight_with_alpha(zero_curv, ALPHA_MAX);
-        assert_eq!(weight_zero, SCALE, "Zero curvature should give weight = SCALE");
+        assert_eq!(
+            weight_zero, SCALE,
+            "Zero curvature should give weight = SCALE"
+        );
 
         // Test that result is always in valid range
-        for curv in [-SCALE, -SCALE/2, 0, SCALE/4, SCALE/2, SCALE] {
+        for curv in [-SCALE, -SCALE / 2, 0, SCALE / 4, SCALE / 2, SCALE] {
             let w = dag.curvature_weight_with_alpha(curv, ALPHA_MAX);
-            assert!(w >= MIN_CURVATURE_WEIGHT && w <= SCALE,
-                    "Weight should always be in range [MIN_CURVATURE_WEIGHT, SCALE]");
+            assert!(
+                (MIN_CURVATURE_WEIGHT..=SCALE).contains(&w),
+                "Weight should always be in range [MIN_CURVATURE_WEIGHT, SCALE]"
+            );
         }
     }
 
     #[test]
     fn test_effective_alpha_at_bootstrap_start() {
         // Test at exactly BOOTSTRAP_START (block 1000) returns 0
-        assert_eq!(effective_alpha(BOOTSTRAP_START), 0,
-                   "Alpha should be 0 at BOOTSTRAP_START");
+        assert_eq!(
+            effective_alpha(BOOTSTRAP_START),
+            0,
+            "Alpha should be 0 at BOOTSTRAP_START"
+        );
     }
 
     #[test]
     fn test_effective_alpha_at_bootstrap_end() {
         // Test at BOOTSTRAP_END (block 6000) returns ALPHA_MAX
-        assert_eq!(effective_alpha(BOOTSTRAP_END), ALPHA_MAX,
-                   "Alpha should be ALPHA_MAX at BOOTSTRAP_END");
+        assert_eq!(
+            effective_alpha(BOOTSTRAP_END),
+            ALPHA_MAX,
+            "Alpha should be ALPHA_MAX at BOOTSTRAP_END"
+        );
     }
 
     #[test]
@@ -1310,24 +1399,34 @@ mod tests {
         let alpha_mid = effective_alpha(midpoint);
 
         // Linear ramp: at midpoint, should be ~ALPHA_MAX/2 = 1.5, rounds to 1
-        assert!(alpha_mid > 0 && alpha_mid < ALPHA_MAX,
-                "Alpha at midpoint should be between 0 and ALPHA_MAX");
+        assert!(
+            alpha_mid > 0 && alpha_mid < ALPHA_MAX,
+            "Alpha at midpoint should be between 0 and ALPHA_MAX"
+        );
 
         // Check it's proportional: at 25% through ramp
         let quarter = BOOTSTRAP_START + (BOOTSTRAP_END - BOOTSTRAP_START) / 4; // 2250
         let alpha_quarter = effective_alpha(quarter);
-        assert!(alpha_quarter < alpha_mid,
-                "Alpha should increase monotonically through ramp");
+        assert!(
+            alpha_quarter < alpha_mid,
+            "Alpha should increase monotonically through ramp"
+        );
     }
 
     #[test]
     fn test_effective_alpha_boundary_conditions() {
         // Test just before and after boundaries
-        assert_eq!(effective_alpha(BOOTSTRAP_START - 1), 0,
-                   "One depth before bootstrap should have alpha=0");
+        assert_eq!(
+            effective_alpha(BOOTSTRAP_START - 1),
+            0,
+            "One depth before bootstrap should have alpha=0"
+        );
 
-        assert_eq!(effective_alpha(BOOTSTRAP_END + 1), ALPHA_MAX,
-                   "One depth after bootstrap should have alpha=ALPHA_MAX");
+        assert_eq!(
+            effective_alpha(BOOTSTRAP_END + 1),
+            ALPHA_MAX,
+            "One depth after bootstrap should have alpha=ALPHA_MAX"
+        );
     }
 
     // ========================================================================

--- a/disentangle-identity/src/capability.rs
+++ b/disentangle-identity/src/capability.rs
@@ -5,11 +5,11 @@
 use crate::did::DID;
 use crate::IdentityError;
 use disentangle_crypto::{
-    hash::{Hash256, sha3_256_multi},
-    signature::{SigningKey, Signature, sign, verify, VerifyingKey},
+    hash::{sha3_256_multi, Hash256},
+    signature::{sign, verify, Signature, SigningKey, VerifyingKey},
 };
 use disentangle_dag::{FixedPoint, SCALE};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 pub type CapabilityId = Hash256;
 
@@ -27,7 +27,12 @@ pub struct Capability {
 
 impl Capability {
     /// Create a new capability signed by the issuer
-    pub fn new(issuer: &DID, _issuer_pk: &VerifyingKey, subject: CapabilitySubject, sk: &SigningKey) -> Self {
+    pub fn new(
+        issuer: &DID,
+        _issuer_pk: &VerifyingKey,
+        subject: CapabilitySubject,
+        sk: &SigningKey,
+    ) -> Self {
         let mut cap = Self {
             id: [0u8; 32],
             issuer: issuer.clone(),
@@ -57,7 +62,8 @@ impl Capability {
             self.delegatable,
             self.max_delegation_depth,
             &self.expiry,
-        )).unwrap_or_default();
+        ))
+        .unwrap_or_default();
 
         sha3_256_multi(&[b"CAPABILITY_ID_V1", &content])
     }
@@ -87,17 +93,32 @@ impl Capability {
             self.delegatable,
             self.max_delegation_depth,
             &self.expiry,
-        )).unwrap_or_default()
+        ))
+        .unwrap_or_default()
     }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum CapabilitySubject {
-    Transact { scope: TransactionScope },
-    Name { namespace: DID, operations: Vec<NameOp> },
-    Access { resource_id: Hash256, operations: Vec<AccessOp> },
-    Govern { scope: GovernanceScope, weight: FixedPoint },
-    Custom { type_uri: String, parameters: Vec<u8> },
+    Transact {
+        scope: TransactionScope,
+    },
+    Name {
+        namespace: DID,
+        operations: Vec<NameOp>,
+    },
+    Access {
+        resource_id: Hash256,
+        operations: Vec<AccessOp>,
+    },
+    Govern {
+        scope: GovernanceScope,
+        weight: FixedPoint,
+    },
+    Custom {
+        type_uri: String,
+        parameters: Vec<u8>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -109,10 +130,18 @@ pub enum TransactionScope {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub enum NameOp { Read, Write, Delegate }
+pub enum NameOp {
+    Read,
+    Write,
+    Delegate,
+}
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub enum AccessOp { Read, Write, Execute }
+pub enum AccessOp {
+    Read,
+    Write,
+    Execute,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum GovernanceScope {
@@ -134,19 +163,16 @@ pub enum Constraint {
 impl Constraint {
     pub fn is_satisfied(&self, context: &ConstraintContext) -> bool {
         match self {
-            Self::TemporalBound { not_before, not_after } => {
-                context.current_depth >= *not_before && context.current_depth <= *not_after
-            }
-            Self::ReputationMinimum { bucket } => {
-                context.reputation_bucket >= *bucket
-            }
+            Self::TemporalBound {
+                not_before,
+                not_after,
+            } => context.current_depth >= *not_before && context.current_depth <= *not_after,
+            Self::ReputationMinimum { bucket } => context.reputation_bucket >= *bucket,
             Self::CoherenceMinimum { min_mass } => {
                 // Compare without overflow: mass/SCALE >= min_mass
                 (context.topological_mass / SCALE) as u64 >= *min_mass
             }
-            Self::DelegationDepth { max_depth } => {
-                context.current_delegation_depth <= *max_depth
-            }
+            Self::DelegationDepth { max_depth } => context.current_delegation_depth <= *max_depth,
             Self::RequiresCapability { prerequisite } => {
                 context.held_capabilities.contains(prerequisite)
             }
@@ -184,7 +210,9 @@ impl DelegationRecord {
         depth: u64,
     ) -> Result<Self, IdentityError> {
         if !cap.delegatable {
-            return Err(IdentityError::ConstraintNotSatisfied("Capability is not delegatable".to_string()));
+            return Err(IdentityError::ConstraintNotSatisfied(
+                "Capability is not delegatable".to_string(),
+            ));
         }
 
         let mut record = Self {
@@ -255,7 +283,8 @@ impl DelegationRecord {
             &self.additional_constraints,
             self.chain_depth,
             self.depth,
-        )).unwrap_or_default()
+        ))
+        .unwrap_or_default()
     }
 }
 
@@ -275,7 +304,9 @@ mod tests {
     fn test_capability_creation() {
         let (sk, pk) = generate_keypair();
         let did = DID::new(&pk, false);
-        let subject = CapabilitySubject::Transact { scope: TransactionScope::All };
+        let subject = CapabilitySubject::Transact {
+            scope: TransactionScope::All,
+        };
 
         let cap = Capability::new(&did, &pk, subject, &sk);
 
@@ -288,7 +319,9 @@ mod tests {
     fn test_capability_id_computation() {
         let (sk, pk) = generate_keypair();
         let did = DID::new(&pk, false);
-        let subject = CapabilitySubject::Transact { scope: TransactionScope::All };
+        let subject = CapabilitySubject::Transact {
+            scope: TransactionScope::All,
+        };
 
         let cap = Capability::new(&did, &pk, subject, &sk);
         let id1 = cap.compute_id();
@@ -302,7 +335,9 @@ mod tests {
     fn test_capability_verification() {
         let (sk, pk) = generate_keypair();
         let did = DID::new(&pk, false);
-        let subject = CapabilitySubject::Transact { scope: TransactionScope::All };
+        let subject = CapabilitySubject::Transact {
+            scope: TransactionScope::All,
+        };
 
         let cap = Capability::new(&did, &pk, subject, &sk);
         assert!(cap.verify(&pk));
@@ -342,7 +377,9 @@ mod tests {
     fn test_delegation_creation() {
         let (sk, pk) = generate_keypair();
         let did = DID::new(&pk, false);
-        let subject = CapabilitySubject::Transact { scope: TransactionScope::All };
+        let subject = CapabilitySubject::Transact {
+            scope: TransactionScope::All,
+        };
 
         let cap = Capability::new(&did, &pk, subject, &sk);
 
@@ -431,7 +468,9 @@ mod tests {
     #[test]
     fn test_requires_capability_passes() {
         let prerequisite_id = [42u8; 32];
-        let constraint = Constraint::RequiresCapability { prerequisite: prerequisite_id };
+        let constraint = Constraint::RequiresCapability {
+            prerequisite: prerequisite_id,
+        };
         let context = ConstraintContext {
             current_depth: 0,
             reputation_bucket: 0,
@@ -445,7 +484,9 @@ mod tests {
     #[test]
     fn test_requires_capability_fails() {
         let prerequisite_id = [42u8; 32];
-        let constraint = Constraint::RequiresCapability { prerequisite: prerequisite_id };
+        let constraint = Constraint::RequiresCapability {
+            prerequisite: prerequisite_id,
+        };
         let context = ConstraintContext {
             current_depth: 0,
             reputation_bucket: 0,
@@ -462,13 +503,18 @@ mod tests {
     fn test_capability_multiple_constraints_all_pass() {
         let (sk, pk) = generate_keypair();
         let did = DID::new(&pk, false);
-        let subject = CapabilitySubject::Transact { scope: TransactionScope::All };
+        let subject = CapabilitySubject::Transact {
+            scope: TransactionScope::All,
+        };
 
         let mut cap = Capability::new(&did, &pk, subject, &sk);
         cap.constraints = vec![
             Constraint::ReputationMinimum { bucket: 2 },
             Constraint::CoherenceMinimum { min_mass: 100 },
-            Constraint::TemporalBound { not_before: 10, not_after: 1000 },
+            Constraint::TemporalBound {
+                not_before: 10,
+                not_after: 1000,
+            },
         ];
 
         let context = ConstraintContext {
@@ -486,13 +532,18 @@ mod tests {
     fn test_capability_multiple_constraints_one_fails() {
         let (sk, pk) = generate_keypair();
         let did = DID::new(&pk, false);
-        let subject = CapabilitySubject::Transact { scope: TransactionScope::All };
+        let subject = CapabilitySubject::Transact {
+            scope: TransactionScope::All,
+        };
 
         let mut cap = Capability::new(&did, &pk, subject, &sk);
         cap.constraints = vec![
-            Constraint::ReputationMinimum { bucket: 2 },  // passes (5 >= 2)
+            Constraint::ReputationMinimum { bucket: 2 }, // passes (5 >= 2)
             Constraint::CoherenceMinimum { min_mass: 100 }, // fails (50 < 100)
-            Constraint::TemporalBound { not_before: 10, not_after: 1000 }, // passes
+            Constraint::TemporalBound {
+                not_before: 10,
+                not_after: 1000,
+            }, // passes
         ];
 
         let context = ConstraintContext {
@@ -512,7 +563,9 @@ mod tests {
     fn test_delegation_non_delegatable_returns_error() {
         let (sk, pk) = generate_keypair();
         let did = DID::new(&pk, false);
-        let subject = CapabilitySubject::Transact { scope: TransactionScope::All };
+        let subject = CapabilitySubject::Transact {
+            scope: TransactionScope::All,
+        };
 
         let mut cap = Capability::new(&did, &pk, subject, &sk);
         cap.delegatable = false; // mark as non-delegatable
@@ -537,7 +590,9 @@ mod tests {
     fn test_delegation_chain_verification() {
         let (sk1, pk1) = generate_keypair();
         let did1 = DID::new(&pk1, false);
-        let subject = CapabilitySubject::Transact { scope: TransactionScope::All };
+        let subject = CapabilitySubject::Transact {
+            scope: TransactionScope::All,
+        };
 
         let cap = Capability::new(&did1, &pk1, subject, &sk1);
 

--- a/disentangle-identity/src/coherence.rs
+++ b/disentangle-identity/src/coherence.rs
@@ -4,8 +4,8 @@
 
 use crate::did::DID;
 use crate::graph::IdentityGraph;
-use disentangle_dag::{FixedPoint, SCALE, MIN_CURVATURE_WEIGHT, fp_mul};
-use serde::{Serialize, Deserialize};
+use disentangle_dag::{fp_mul, FixedPoint, MIN_CURVATURE_WEIGHT, SCALE};
+use serde::{Deserialize, Serialize};
 
 pub const COHERENCE_HALF_LIFE: u64 = 10_000;
 
@@ -74,7 +74,7 @@ impl CoherenceProfile {
             mean_local_curvature,
             relational_diversity: positive_curvature_count,
             temporal_depth: current_depth.saturating_sub(first_seen_depth),
-            capability_coherence: 0, // Placeholder for Phase 1
+            capability_coherence: 0,   // Placeholder for Phase 1
             introduction_coherence: 0, // Placeholder for Phase 1
             last_active_depth: current_depth,
         }
@@ -151,7 +151,7 @@ impl CoherenceProfile {
 mod tests {
     use super::*;
     use crate::graph::IdentityGraph;
-    use crate::transactions::{IntroductionTransaction, IntroductionContext};
+    use crate::transactions::{IntroductionContext, IntroductionTransaction};
     use disentangle_crypto::signature::generate_keypair;
 
     #[test]

--- a/disentangle-identity/src/did.rs
+++ b/disentangle-identity/src/did.rs
@@ -3,10 +3,10 @@
 //! Implements the did:disentangle DID method with support for Human, AGI, and Hybrid agent types.
 
 use disentangle_crypto::{
-    hash::{Hash256, sha3_256, sha3_256_multi},
-    signature::{VerifyingKey, Signature, SigningKey, sign, verify},
+    hash::{sha3_256, sha3_256_multi, Hash256},
+    signature::{sign, verify, Signature, SigningKey, VerifyingKey},
 };
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 pub type CapabilityRef = String;
 
@@ -60,7 +60,12 @@ pub struct DIDDocument {
 
 impl DIDDocument {
     /// Create a new DID document signed with the provided key
-    pub fn new(signing_key: &SigningKey, verifying_key: &VerifyingKey, agent_type: AgentType, depth: u64) -> Self {
+    pub fn new(
+        signing_key: &SigningKey,
+        verifying_key: &VerifyingKey,
+        agent_type: AgentType,
+        depth: u64,
+    ) -> Self {
         let is_agi = matches!(agent_type, AgentType::AGI { .. });
         let did = DID::new(verifying_key, is_agi);
 
@@ -142,8 +147,13 @@ impl DIDDocument {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum AgentType {
     Human,
-    AGI { runtime_attestation: Option<RuntimeAttestation> },
-    Hybrid { human_did: DID, agi_did: DID },
+    AGI {
+        runtime_attestation: Option<RuntimeAttestation>,
+    },
+    Hybrid {
+        human_did: DID,
+        agi_did: DID,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -280,7 +290,9 @@ mod tests {
         let (sk, pk) = generate_keypair();
         let mut doc = DIDDocument::new(&sk, &pk, AgentType::Human, 500);
         // Tamper: change agent type from Human to AGI
-        doc.agent_type = AgentType::AGI { runtime_attestation: None };
+        doc.agent_type = AgentType::AGI {
+            runtime_attestation: None,
+        };
         assert!(!doc.verify());
     }
 
@@ -317,7 +329,10 @@ mod tests {
 
         // Verify the agent type was preserved
         match &doc.agent_type {
-            AgentType::Hybrid { human_did: h, agi_did: a } => {
+            AgentType::Hybrid {
+                human_did: h,
+                agi_did: a,
+            } => {
                 assert_eq!(h, &human_did);
                 assert_eq!(a, &agi_did);
             }
@@ -334,10 +349,7 @@ mod tests {
         let human_did = DID::new(&pk_human, false);
         let agi_did = DID::new(&pk_agi, true);
 
-        let agent_type = AgentType::Hybrid {
-            human_did,
-            agi_did,
-        };
+        let agent_type = AgentType::Hybrid { human_did, agi_did };
 
         let doc = DIDDocument::new(&sk, &pk, agent_type, 2000);
 

--- a/disentangle-identity/src/governance.rs
+++ b/disentangle-identity/src/governance.rs
@@ -2,15 +2,15 @@
 //!
 //! Coherence-weighted governance with proposals, voting, and quorum evaluation.
 
-use crate::did::DID;
 use crate::coherence::CoherenceProfile;
+use crate::did::DID;
 use crate::transactions::TransactionIdentity;
 use disentangle_crypto::{
-    hash::{Hash256, sha3_256_multi},
-    signature::{SigningKey, Signature, sign, verify, VerifyingKey},
+    hash::{sha3_256_multi, Hash256},
+    signature::{sign, verify, Signature, SigningKey, VerifyingKey},
 };
 use disentangle_dag::{FixedPoint, SCALE};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -91,10 +91,19 @@ impl GovernanceProposal {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ProposalType {
-    ProtocolParameter { parameter: String, new_value: Vec<u8> },
-    CapabilityPolicy { policy: Vec<u8> },
-    NamingHubRecognition { hub_did: DID },
-    EmergencyAction { action: Vec<u8> },
+    ProtocolParameter {
+        parameter: String,
+        new_value: Vec<u8>,
+    },
+    CapabilityPolicy {
+        policy: Vec<u8>,
+    },
+    NamingHubRecognition {
+        hub_did: DID,
+    },
+    EmergencyAction {
+        action: Vec<u8>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -129,8 +138,13 @@ pub enum VoteChoice {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum GovernanceQuorum {
-    CoherenceWeighted { threshold: FixedPoint },
-    DiversityMinimum { min_supporters: u64, min_mass: FixedPoint },
+    CoherenceWeighted {
+        threshold: FixedPoint,
+    },
+    DiversityMinimum {
+        min_supporters: u64,
+        min_mass: FixedPoint,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -156,7 +170,8 @@ pub fn evaluate_proposal(
     }
 
     // Filter votes for this proposal within voting period
-    let relevant_votes: Vec<&GovernanceVote> = votes.iter()
+    let relevant_votes: Vec<&GovernanceVote> = votes
+        .iter()
         .filter(|v| v.proposal_id == proposal.id)
         .filter(|v| v.depth >= proposal.voting_start && v.depth <= proposal.voting_end)
         .collect();
@@ -203,7 +218,10 @@ pub fn evaluate_proposal(
                 ProposalResult::Failed
             }
         }
-        GovernanceQuorum::DiversityMinimum { min_supporters, min_mass } => {
+        GovernanceQuorum::DiversityMinimum {
+            min_supporters,
+            min_mass,
+        } => {
             if unique_supporters >= *min_supporters && for_weight >= *min_mass as i64 {
                 ProposalResult::Passed
             } else {
@@ -216,8 +234,8 @@ pub fn evaluate_proposal(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use disentangle_crypto::signature::generate_keypair;
     use crate::transactions::TransactionIdentity;
+    use disentangle_crypto::signature::generate_keypair;
     use disentangle_crypto::types::Nullifier;
 
     #[test]
@@ -236,7 +254,9 @@ mod tests {
             [1u8; 32],
             1000,
             2000,
-            GovernanceQuorum::CoherenceWeighted { threshold: SCALE / 2 },
+            GovernanceQuorum::CoherenceWeighted {
+                threshold: SCALE / 2,
+            },
             &sk,
         );
 
@@ -261,7 +281,9 @@ mod tests {
             [1u8; 32],
             1000,
             2000,
-            GovernanceQuorum::CoherenceWeighted { threshold: SCALE / 2 },
+            GovernanceQuorum::CoherenceWeighted {
+                threshold: SCALE / 2,
+            },
             &sk,
         );
 
@@ -282,7 +304,9 @@ mod tests {
             [1u8; 32],
             1000,
             2000,
-            GovernanceQuorum::CoherenceWeighted { threshold: SCALE / 2 },
+            GovernanceQuorum::CoherenceWeighted {
+                threshold: SCALE / 2,
+            },
             &sk,
         );
 
@@ -308,7 +332,9 @@ mod tests {
             [1u8; 32],
             1000,
             2000,
-            GovernanceQuorum::CoherenceWeighted { threshold: SCALE / 2 }, // 50% threshold
+            GovernanceQuorum::CoherenceWeighted {
+                threshold: SCALE / 2,
+            }, // 50% threshold
             &sk,
         );
 

--- a/disentangle-identity/src/graph.rs
+++ b/disentangle-identity/src/graph.rs
@@ -2,12 +2,12 @@
 //!
 //! Tracks introductions, delegations, and computes identity curvature.
 
-use crate::did::DID;
 use crate::capability::{CapabilityId, DelegationRecord, RevocationScope};
+use crate::did::DID;
 use crate::petname::IntroductionStep;
-use crate::transactions::{IntroductionTransaction, IntroductionContext};
+use crate::transactions::{IntroductionContext, IntroductionTransaction};
 use disentangle_crypto::hash::Hash256;
-use disentangle_dag::{FixedPoint, SCALE, fp_from_ratio};
+use disentangle_dag::{fp_from_ratio, FixedPoint, SCALE};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Default)]
@@ -45,27 +45,32 @@ impl IdentityGraph {
         self.introductions.entry(key).or_default().push(record);
 
         // Update neighbors
-        self.did_neighbors.entry(tx.introducer_did.clone())
+        self.did_neighbors
+            .entry(tx.introducer_did.clone())
             .or_default()
             .insert(tx.introduced_did.clone());
 
-        self.did_neighbors.entry(tx.introduced_did.clone())
+        self.did_neighbors
+            .entry(tx.introduced_did.clone())
             .or_default()
             .insert(tx.introducer_did.clone());
     }
 
     /// Record a capability delegation
     pub fn record_delegation(&mut self, record: &DelegationRecord) {
-        self.delegations.entry(record.capability_id)
+        self.delegations
+            .entry(record.capability_id)
             .or_default()
             .push(record.clone());
 
         // Update neighbors based on delegation
-        self.did_neighbors.entry(record.delegator.clone())
+        self.did_neighbors
+            .entry(record.delegator.clone())
             .or_default()
             .insert(record.delegatee.clone());
 
-        self.did_neighbors.entry(record.delegatee.clone())
+        self.did_neighbors
+            .entry(record.delegatee.clone())
             .or_default()
             .insert(record.delegator.clone());
     }
@@ -166,7 +171,8 @@ impl IdentityGraph {
 
     /// Get the delegation chain for a capability
     pub fn delegation_chain(&self, cap: &CapabilityId) -> Vec<&DelegationRecord> {
-        self.delegations.get(cap)
+        self.delegations
+            .get(cap)
             .map(|records| records.iter().collect())
             .unwrap_or_default()
     }

--- a/disentangle-identity/src/lib.rs
+++ b/disentangle-identity/src/lib.rs
@@ -14,32 +14,34 @@
 //! This is Phase 1 of the implementation, providing core types without ZK proofs
 //! or networking. ZK integration (Phase 2) and full DAG integration (Phase 3) will follow.
 
-pub mod did;
 pub mod capability;
+pub mod coherence;
+pub mod did;
+pub mod governance;
+pub mod graph;
 pub mod petname;
 pub mod transactions;
-pub mod graph;
-pub mod coherence;
-pub mod governance;
 
 // Re-export main types
-pub use did::{DID, DIDDocument, AgentType, VerificationMethod, VerificationMethodType, RuntimeAttestation, ServiceEndpoint};
 pub use capability::{
-    Capability, CapabilityId, CapabilitySubject, Constraint, DelegationRecord,
-    TransactionScope, NameOp, AccessOp, GovernanceScope, RevocationScope, ConstraintContext,
+    AccessOp, Capability, CapabilityId, CapabilitySubject, Constraint, ConstraintContext,
+    DelegationRecord, GovernanceScope, NameOp, RevocationScope, TransactionScope,
 };
-pub use petname::{PetnameDB, PetnameEntry, IntroductionStep, ProposedName};
-pub use transactions::{
-    DisentangleTransaction, IdentityTransaction, CapabilityTransaction,
-    IntroductionTransaction, GovernanceTransaction, TransactionIdentity,
-    DIDRegistration, DIDUpdate, DIDUpdateOp, DIDDeactivation, KeyRotation,
-    IntroductionContext, CapabilityOperation,
+pub use coherence::{CoherenceProfile, COHERENCE_HALF_LIFE};
+pub use did::{
+    AgentType, DIDDocument, RuntimeAttestation, ServiceEndpoint, VerificationMethod,
+    VerificationMethodType, DID,
+};
+pub use governance::{
+    evaluate_proposal, GovernanceProposal, GovernanceQuorum, GovernanceVote, ProposalResult,
+    ProposalType, VoteChoice,
 };
 pub use graph::IdentityGraph;
-pub use coherence::{CoherenceProfile, COHERENCE_HALF_LIFE};
-pub use governance::{
-    GovernanceProposal, GovernanceVote, VoteChoice, GovernanceQuorum,
-    ProposalType, ProposalResult, evaluate_proposal,
+pub use petname::{IntroductionStep, PetnameDB, PetnameEntry, ProposedName};
+pub use transactions::{
+    CapabilityOperation, CapabilityTransaction, DIDDeactivation, DIDRegistration, DIDUpdate,
+    DIDUpdateOp, DisentangleTransaction, GovernanceTransaction, IdentityTransaction,
+    IntroductionContext, IntroductionTransaction, KeyRotation, TransactionIdentity,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -245,7 +247,9 @@ mod tests {
             [1u8; 32],
             1000,
             2000,
-            GovernanceQuorum::CoherenceWeighted { threshold: SCALE / 2 },
+            GovernanceQuorum::CoherenceWeighted {
+                threshold: SCALE / 2,
+            },
             &sk,
         );
 

--- a/disentangle-identity/src/petname.rs
+++ b/disentangle-identity/src/petname.rs
@@ -6,7 +6,7 @@ use crate::did::DID;
 use crate::graph::IdentityGraph;
 use crate::IdentityError;
 use disentangle_crypto::hash::Hash256;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -49,7 +49,13 @@ impl PetnameDB {
     }
 
     /// Bind a petname to a DID with a trust path
-    pub fn bind(&mut self, name: &str, did: &DID, trust_path: Vec<IntroductionStep>, depth: u64) -> Result<(), IdentityError> {
+    pub fn bind(
+        &mut self,
+        name: &str,
+        did: &DID,
+        trust_path: Vec<IntroductionStep>,
+        depth: u64,
+    ) -> Result<(), IdentityError> {
         // Check if name is already bound
         if self.petnames.contains_key(name) {
             return Err(IdentityError::PetnameAlreadyBound(name.to_string()));
@@ -76,7 +82,10 @@ impl PetnameDB {
             self.did_to_petname.remove(&entry.did);
             Ok(())
         } else {
-            Err(IdentityError::DIDNotFound(format!("Petname not found: {}", name)))
+            Err(IdentityError::DIDNotFound(format!(
+                "Petname not found: {}",
+                name
+            )))
         }
     }
 
@@ -95,7 +104,11 @@ impl PetnameDB {
     /// If an IdentityGraph is provided, edges with negative curvature are
     /// skipped during resolution (curvature gate per CCIP spec). This
     /// prevents Sybil entities from polluting the namespace.
-    pub fn resolve_edge_path(&self, path: &str, identity_graph: Option<&IdentityGraph>) -> Option<&DID> {
+    pub fn resolve_edge_path(
+        &self,
+        path: &str,
+        identity_graph: Option<&IdentityGraph>,
+    ) -> Option<&DID> {
         let parts: Vec<&str> = path.split("=>").map(|s| s.trim()).collect();
 
         if parts.len() < 2 {
@@ -129,14 +142,13 @@ impl PetnameDB {
 
     /// Add a proposed name with auto-disambiguation
     pub fn add_proposed_name(&mut self, did: &DID, name: &str) {
-        let count = self.proposed_name_counts.entry(name.to_string()).or_insert(0);
+        let count = self
+            .proposed_name_counts
+            .entry(name.to_string())
+            .or_insert(0);
         *count += 1;
 
-        let disambiguation = if *count > 1 {
-            Some(*count)
-        } else {
-            None
-        };
+        let disambiguation = if *count > 1 { Some(*count) } else { None };
 
         let proposed = ProposedName {
             name: name.to_string(),
@@ -144,7 +156,10 @@ impl PetnameDB {
             disambiguation,
         };
 
-        self.proposed_names.entry(did.clone()).or_default().push(proposed);
+        self.proposed_names
+            .entry(did.clone())
+            .or_default()
+            .push(proposed);
     }
 
     /// Get a display name for a DID (priority: petname > edge name > proposed > truncated DID)
@@ -183,7 +198,7 @@ impl PetnameDB {
         // 4. Truncated DID
         let method_id = did.method_specific_id();
         if method_id.len() > 16 {
-            format!("{}…{}", &method_id[..8], &method_id[method_id.len()-4..])
+            format!("{}…{}", &method_id[..8], &method_id[method_id.len() - 4..])
         } else {
             method_id.to_string()
         }
@@ -297,9 +312,9 @@ mod tests {
 
     #[test]
     fn test_edge_path_curvature_gate() {
-        use crate::graph::IdentityGraph;
         use crate::did::DID;
-        use crate::transactions::{IntroductionTransaction, IntroductionContext};
+        use crate::graph::IdentityGraph;
+        use crate::transactions::{IntroductionContext, IntroductionTransaction};
         use disentangle_crypto::signature::generate_keypair;
 
         let mut db = PetnameDB::new();
@@ -410,11 +425,21 @@ mod tests {
 
         let curv_bob = graph.identity_curvature(&alice, &bob);
         let curv_sybil = graph.identity_curvature(&alice, &sybil);
-        assert!(curv_bob >= 0, "alice->bob should have non-negative curvature, got {}", curv_bob);
-        assert!(curv_sybil < 0, "alice->sybil should have negative curvature, got {}", curv_sybil);
+        assert!(
+            curv_bob >= 0,
+            "alice->bob should have non-negative curvature, got {}",
+            curv_bob
+        );
+        assert!(
+            curv_sybil < 0,
+            "alice->sybil should have negative curvature, got {}",
+            curv_sybil
+        );
 
         // With curvature gate, sybil path should fail
         assert!(db.resolve_edge_path("Alice => Bob", Some(&graph)).is_some());
-        assert!(db.resolve_edge_path("Alice => Sybil", Some(&graph)).is_none());
+        assert!(db
+            .resolve_edge_path("Alice => Sybil", Some(&graph))
+            .is_none());
     }
 }

--- a/disentangle-identity/src/transactions.rs
+++ b/disentangle-identity/src/transactions.rs
@@ -2,17 +2,17 @@
 //!
 //! Transaction types for identity, capability, introduction, and governance operations.
 
-use crate::did::{DID, DIDDocument, AgentType, VerificationMethod, ServiceEndpoint};
 use crate::capability::{Capability, CapabilityId, DelegationRecord, RevocationScope};
-use crate::governance::{GovernanceVote};
+use crate::did::{AgentType, DIDDocument, ServiceEndpoint, VerificationMethod, DID};
+use crate::governance::GovernanceVote;
 use disentangle_crypto::{
-    hash::{Hash256, sha3_256_multi},
-    signature::{Signature, VerifyingKey, verify},
+    hash::{sha3_256_multi, Hash256},
+    signature::{verify, Signature, VerifyingKey},
     types::Nullifier,
 };
 use disentangle_dag::Transaction;
 use disentangle_simhash::SimHash;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 // Domain separation tags
 const _TX_TAG_LEGACY: &[u8] = b"TX_LEGACY_V2";
@@ -84,9 +84,7 @@ impl DIDRegistration {
     }
 
     pub fn verify_pow(&self, difficulty: u32) -> bool {
-        let leading_zeros = self.pow_hash.iter()
-            .take_while(|&&b| b == 0)
-            .count() * 8;
+        let leading_zeros = self.pow_hash.iter().take_while(|&&b| b == 0).count() * 8;
 
         leading_zeros >= difficulty as usize
     }
@@ -197,8 +195,8 @@ impl KeyRotation {
 
     pub fn verify_signatures(&self, old_pk: &VerifyingKey, new_pk: &VerifyingKey) -> bool {
         let message = self.signing_payload();
-        verify(old_pk, &message, &self.proof_old).is_ok() &&
-        verify(new_pk, &message, &self.proof_new).is_ok()
+        verify(old_pk, &message, &self.proof_old).is_ok()
+            && verify(new_pk, &message, &self.proof_new).is_ok()
     }
 
     fn signing_payload(&self) -> Vec<u8> {
@@ -291,7 +289,7 @@ impl CapabilityTransaction {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransactionIdentity {
     pub ephemeral_pk: VerifyingKey,
-    pub did_binding_proof: Vec<u8>,   // Serialized STARK proof (Phase 2)
+    pub did_binding_proof: Vec<u8>, // Serialized STARK proof (Phase 2)
     pub nullifier: Nullifier,
     pub reputation_bucket: u8,
 }
@@ -300,7 +298,7 @@ pub struct TransactionIdentity {
 pub enum CapabilityOperation {
     Invoke {
         capability_id: CapabilityId,
-        invocation_proof: Vec<u8>,    // Serialized STARK proof (Phase 2)
+        invocation_proof: Vec<u8>, // Serialized STARK proof (Phase 2)
         action: Vec<u8>,
     },
     Delegate(DelegationRecord),
@@ -323,19 +321,15 @@ pub struct GovernanceTransaction {
 impl GovernanceTransaction {
     pub fn compute_id(&self) -> Hash256 {
         let vote_bytes = bincode::serialize(&self.vote).unwrap_or_default();
-        sha3_256_multi(&[
-            TX_TAG_GOVERNANCE,
-            &vote_bytes,
-            &self.depth.to_le_bytes(),
-        ])
+        sha3_256_multi(&[TX_TAG_GOVERNANCE, &vote_bytes, &self.depth.to_le_bytes()])
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use disentangle_crypto::signature::{generate_keypair, sign};
     use crate::did::AgentType;
+    use disentangle_crypto::signature::{generate_keypair, sign};
 
     #[test]
     fn test_did_registration_id() {

--- a/disentangle-identity/tests/cross_crate_curvature_test.rs
+++ b/disentangle-identity/tests/cross_crate_curvature_test.rs
@@ -12,11 +12,13 @@
 //! This test constructs equivalent topologies in both representations and verifies
 //! they produce the same curvature values, ensuring the two implementations stay in sync.
 
-use disentangle_dag::{TransactionDAG, Transaction, NodeId, SCALE, Hash256, FixedPoint, fp_from_ratio};
-use disentangle_identity::{IdentityGraph, DID, IntroductionTransaction, IntroductionContext};
-use disentangle_crypto::signature::{generate_keypair, SigningKey, VerifyingKey};
 use disentangle_crypto::hash::sha3_256;
-use disentangle_crypto::types::{Nullifier, Epoch};
+use disentangle_crypto::signature::{generate_keypair, SigningKey, VerifyingKey};
+use disentangle_crypto::types::{Epoch, Nullifier};
+use disentangle_dag::{
+    fp_from_ratio, FixedPoint, Hash256, NodeId, Transaction, TransactionDAG, SCALE,
+};
+use disentangle_identity::{IdentityGraph, IntroductionContext, IntroductionTransaction, DID};
 use disentangle_simhash::SimHash;
 
 /// Helper: create a test transaction for the DAG
@@ -28,7 +30,7 @@ fn make_dag_tx(
 ) -> Transaction {
     let (sk, pk) = keypair;
     let history_root = sha3_256(format!("history:{}", name).as_bytes());
-    let parent_hashes: Vec<Hash256> = parents.iter().cloned().collect();
+    let parent_hashes: Vec<Hash256> = parents.to_vec();
     let simhash = SimHash::from_structural(&parent_hashes, &history_root);
     let nullifier = Nullifier::compute(
         &sha3_256(format!("secret:{}", name).as_bytes()),
@@ -140,19 +142,27 @@ fn test_curvature_formula_equivalence_shared_neighbors() {
     });
 
     let id_curvature = id_graph.identity_curvature(&did_a, &did_b);
-    println!("    Identity curvature (A, B): {} (scaled: {:.4})",
-        id_curvature, id_curvature as f64 / SCALE as f64);
+    println!(
+        "    Identity curvature (A, B): {} (scaled: {:.4})",
+        id_curvature,
+        id_curvature as f64 / SCALE as f64
+    );
 
     // Verify that the identity curvature matches the manual Jaccard computation.
     // Neighbors(A) = {C, D}, Neighbors(B) = {C, D}
     // Intersection = {C, D} = 2, Union = {C, D} = 2
     // Jaccard = 2/2 = 1.0, kappa = 2*1.0 - 1 = 1.0
     let expected = jaccard_curvature(&["C", "D"], &["C", "D"]);
-    println!("    Expected (manual Jaccard): {} (scaled: {:.4})",
-        expected, expected as f64 / SCALE as f64);
+    println!(
+        "    Expected (manual Jaccard): {} (scaled: {:.4})",
+        expected,
+        expected as f64 / SCALE as f64
+    );
 
-    assert_eq!(id_curvature, expected,
-        "Identity curvature should match manual Jaccard computation");
+    assert_eq!(
+        id_curvature, expected,
+        "Identity curvature should match manual Jaccard computation"
+    );
 
     // --- DAG side ---
     // Build a DAG where two nodes have the same ancestor overlap.
@@ -190,18 +200,29 @@ fn test_curvature_formula_equivalence_shared_neighbors() {
     dag.insert_genesis(v_tx);
 
     let dag_curvature = dag.discrete_curvature(&u_id, &v_id);
-    println!("    DAG curvature (u, v): {} (scaled: {:.4})",
-        dag_curvature, dag_curvature as f64 / SCALE as f64);
+    println!(
+        "    DAG curvature (u, v): {} (scaled: {:.4})",
+        dag_curvature,
+        dag_curvature as f64 / SCALE as f64
+    );
 
     // Both should yield maximum Jaccard curvature (1.0) = SCALE
-    assert_eq!(dag_curvature, SCALE,
-        "DAG curvature should equal SCALE (1.0) for identical ancestor sets");
-    assert_eq!(id_curvature, SCALE,
-        "Identity curvature should equal SCALE (1.0) for identical neighbor sets");
-    assert_eq!(dag_curvature, id_curvature,
-        "DAG and identity curvature should be identical for equivalent structures");
+    assert_eq!(
+        dag_curvature, SCALE,
+        "DAG curvature should equal SCALE (1.0) for identical ancestor sets"
+    );
+    assert_eq!(
+        id_curvature, SCALE,
+        "Identity curvature should equal SCALE (1.0) for identical neighbor sets"
+    );
+    assert_eq!(
+        dag_curvature, id_curvature,
+        "DAG and identity curvature should be identical for equivalent structures"
+    );
 
-    println!("\nTEST PASSED: Curvature formulas produce identical results for shared-neighbor case\n");
+    println!(
+        "\nTEST PASSED: Curvature formulas produce identical results for shared-neighbor case\n"
+    );
 }
 
 #[test]
@@ -252,17 +273,24 @@ fn test_curvature_formula_equivalence_disjoint() {
     });
 
     let id_curvature = id_graph.identity_curvature(&did_a, &did_b);
-    println!("    Identity curvature (A, B): {} (scaled: {:.4})",
-        id_curvature, id_curvature as f64 / SCALE as f64);
+    println!(
+        "    Identity curvature (A, B): {} (scaled: {:.4})",
+        id_curvature,
+        id_curvature as f64 / SCALE as f64
+    );
 
     // Neighbors(A) = {C}, Neighbors(B) = {D}
     // Intersection = 0, Union = {C, D} = 2
     // Jaccard = 0/2 = 0, kappa = 2*0 - 1 = -1.0 = -SCALE
     let expected = jaccard_curvature(&["C"], &["D"]);
-    assert_eq!(id_curvature, expected,
-        "Identity curvature should be -SCALE for disjoint neighbors");
-    assert_eq!(id_curvature, -SCALE,
-        "Identity curvature should be exactly -SCALE (-1.0)");
+    assert_eq!(
+        id_curvature, expected,
+        "Identity curvature should be -SCALE for disjoint neighbors"
+    );
+    assert_eq!(
+        id_curvature, -SCALE,
+        "Identity curvature should be exactly -SCALE (-1.0)"
+    );
 
     // --- DAG side ---
     // Two nodes with completely disjoint ancestor sets:
@@ -293,13 +321,20 @@ fn test_curvature_formula_equivalence_disjoint() {
     dag.insert_genesis(v_tx);
 
     let dag_curvature = dag.discrete_curvature(&u_id, &v_id);
-    println!("    DAG curvature (u, v): {} (scaled: {:.4})",
-        dag_curvature, dag_curvature as f64 / SCALE as f64);
+    println!(
+        "    DAG curvature (u, v): {} (scaled: {:.4})",
+        dag_curvature,
+        dag_curvature as f64 / SCALE as f64
+    );
 
-    assert_eq!(dag_curvature, -SCALE,
-        "DAG curvature should be -SCALE for disjoint ancestor sets");
-    assert_eq!(dag_curvature, id_curvature,
-        "DAG and identity curvature should match for disjoint case");
+    assert_eq!(
+        dag_curvature, -SCALE,
+        "DAG curvature should be -SCALE for disjoint ancestor sets"
+    );
+    assert_eq!(
+        dag_curvature, id_curvature,
+        "DAG and identity curvature should match for disjoint case"
+    );
 
     println!("\nTEST PASSED: Curvature formulas produce identical results for disjoint case\n");
 }
@@ -378,16 +413,24 @@ fn test_curvature_formula_equivalence_partial_overlap() {
     });
 
     let id_curvature = id_graph.identity_curvature(&did_a, &did_b);
-    println!("    Identity curvature (A, B): {} (scaled: {:.4})",
-        id_curvature, id_curvature as f64 / SCALE as f64);
+    println!(
+        "    Identity curvature (A, B): {} (scaled: {:.4})",
+        id_curvature,
+        id_curvature as f64 / SCALE as f64
+    );
 
     // Manual: intersection=1, union=3, Jaccard=1/3, kappa=2/3-1=-1/3
     let expected = jaccard_curvature(&["C", "D"], &["C", "E"]);
-    println!("    Expected (manual): {} (scaled: {:.4})",
-        expected, expected as f64 / SCALE as f64);
+    println!(
+        "    Expected (manual): {} (scaled: {:.4})",
+        expected,
+        expected as f64 / SCALE as f64
+    );
 
-    assert_eq!(id_curvature, expected,
-        "Identity curvature should match manual Jaccard for partial overlap");
+    assert_eq!(
+        id_curvature, expected,
+        "Identity curvature should match manual Jaccard for partial overlap"
+    );
 
     // --- DAG side ---
     // Build a DAG where ancestors(u, 1) = {P_shared, P_only_u}
@@ -440,8 +483,11 @@ fn test_curvature_formula_equivalence_partial_overlap() {
     dag.insert_genesis(v_tx);
 
     let dag_curvature = dag.discrete_curvature(&u_id, &v_id);
-    println!("    DAG curvature (u, v): {} (scaled: {:.4})",
-        dag_curvature, dag_curvature as f64 / SCALE as f64);
+    println!(
+        "    DAG curvature (u, v): {} (scaled: {:.4})",
+        dag_curvature,
+        dag_curvature as f64 / SCALE as f64
+    );
 
     // Both should be approximately -1/3 * SCALE
     // Allow a tolerance of 1 for fixed-point rounding
@@ -449,14 +495,18 @@ fn test_curvature_formula_equivalence_partial_overlap() {
     assert!(
         (dag_curvature - id_curvature).abs() <= tolerance,
         "DAG curvature ({}) and identity curvature ({}) should match within tolerance {}",
-        dag_curvature, id_curvature, tolerance,
+        dag_curvature,
+        id_curvature,
+        tolerance,
     );
 
     // Also verify against the manual computation
     assert!(
         (dag_curvature - expected).abs() <= tolerance,
         "DAG curvature ({}) should match manual Jaccard ({}) within tolerance {}",
-        dag_curvature, expected, tolerance,
+        dag_curvature,
+        expected,
+        tolerance,
     );
 
     println!("\nTEST PASSED: Curvature formulas produce equivalent results for partial overlap\n");
@@ -481,7 +531,10 @@ fn test_curvature_formula_equivalence_empty_neighbors() {
 
     let id_curvature = id_graph.identity_curvature(&did_a, &did_b);
     println!("    Identity curvature (no neighbors): {}", id_curvature);
-    assert_eq!(id_curvature, 0, "Identity curvature should be 0 for nodes with no neighbors");
+    assert_eq!(
+        id_curvature, 0,
+        "Identity curvature should be 0 for nodes with no neighbors"
+    );
 
     // --- DAG side ---
     // Two genesis transactions with no parents
@@ -499,10 +552,15 @@ fn test_curvature_formula_equivalence_empty_neighbors() {
 
     let dag_curvature = dag.discrete_curvature(&u_id, &v_id);
     println!("    DAG curvature (no ancestors): {}", dag_curvature);
-    assert_eq!(dag_curvature, 0, "DAG curvature should be 0 for nodes with no ancestors");
+    assert_eq!(
+        dag_curvature, 0,
+        "DAG curvature should be 0 for nodes with no ancestors"
+    );
 
-    assert_eq!(dag_curvature, id_curvature,
-        "Both formulas should return 0 for the empty case");
+    assert_eq!(
+        dag_curvature, id_curvature,
+        "Both formulas should return 0 for the empty case"
+    );
 
     println!("\nTEST PASSED: Curvature formulas agree on empty neighbor sets\n");
 }

--- a/disentangle-node/src/identity_rpc.rs
+++ b/disentangle-node/src/identity_rpc.rs
@@ -3,20 +3,19 @@
 //! Axum route handlers for the Capability-Coherence Identity Protocol (CCIP).
 //! These handlers provide JSON-over-HTTP access to the IdentityStateManager.
 
+use crate::identity_state::IdentityStateManager;
 use axum::{
     extract::{Path, State},
     http::StatusCode,
     Json,
 };
+use disentangle_crypto::signature::SigningKey;
+use disentangle_identity::{
+    AgentType, CapabilitySubject, Constraint, ProposalType, RevocationScope, VoteChoice,
+};
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use serde::{Deserialize, Serialize};
-use disentangle_crypto::signature::SigningKey;
-use crate::identity_state::IdentityStateManager;
-use disentangle_identity::{
-    AgentType, CapabilitySubject, Constraint, RevocationScope,
-    ProposalType, VoteChoice,
-};
 
 pub type IdentityState = Arc<Mutex<IdentityStateManager>>;
 
@@ -53,34 +52,43 @@ pub async fn identity_register_handler(
 
     let agent_type = match req.agent_type.to_lowercase().as_str() {
         "human" => AgentType::Human,
-        "agi" => AgentType::AGI { runtime_attestation: None },
-        _ => return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: format!("Invalid agent_type: must be 'human' or 'agi', got '{}'", req.agent_type),
-                coherence_score: None,
-            })
-        )),
+        "agi" => AgentType::AGI {
+            runtime_attestation: None,
+        },
+        _ => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!(
+                        "Invalid agent_type: must be 'human' or 'agi', got '{}'",
+                        req.agent_type
+                    ),
+                    coherence_score: None,
+                }),
+            ))
+        }
     };
 
-    let (did, doc, sk) = mgr.register_did(agent_type)
-        .map_err(|e| (
+    let (did, doc, sk) = mgr.register_did(agent_type).map_err(|e| {
+        (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
                 error: format!("Failed to register DID: {}", e),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
     let sk_hex = hex::encode(sk.to_bytes());
-    let doc_json = serde_json::to_value(&doc)
-        .map_err(|e| (
+    let doc_json = serde_json::to_value(&doc).map_err(|e| {
+        (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
                 error: format!("Failed to serialize document: {}", e),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
     Ok(Json(RegisterResponse {
         did: did.0,
@@ -100,27 +108,27 @@ pub async fn identity_get_handler(
 ) -> Result<Json<GetIdentityResponse>, (StatusCode, Json<ErrorResponse>)> {
     let mgr = state.lock().await;
 
-    let doc = mgr.get_did_document(&did)
-        .ok_or_else(|| (
+    let doc = mgr.get_did_document(&did).ok_or_else(|| {
+        (
             StatusCode::NOT_FOUND,
             Json(ErrorResponse {
                 error: format!("DID not found: {}", did),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
-    let doc_json = serde_json::to_value(doc)
-        .map_err(|e| (
+    let doc_json = serde_json::to_value(doc).map_err(|e| {
+        (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
                 error: format!("Failed to serialize document: {}", e),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
-    Ok(Json(GetIdentityResponse {
-        document: doc_json,
-    }))
+    Ok(Json(GetIdentityResponse { document: doc_json }))
 }
 
 #[derive(Serialize)]
@@ -154,23 +162,25 @@ pub async fn identity_deactivate_handler(
 ) -> Result<Json<SuccessResponse>, (StatusCode, Json<ErrorResponse>)> {
     let mut mgr = state.lock().await;
 
-    let proof = hex::decode(&req.proof_hex)
-        .map_err(|_| (
+    let proof = hex::decode(&req.proof_hex).map_err(|_| {
+        (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: "Invalid proof hex encoding".to_string(),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
-    mgr.deactivate_did(&did, &proof)
-        .map_err(|e| (
+    mgr.deactivate_did(&did, &proof).map_err(|e| {
+        (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
                 error: format!("Failed to deactivate DID: {}", e),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
     Ok(Json(SuccessResponse { success: true }))
 }
@@ -198,67 +208,73 @@ pub async fn capability_create_handler(
 ) -> Result<Json<CreateCapabilityResponse>, (StatusCode, Json<ErrorResponse>)> {
     let mut mgr = state.lock().await;
 
-    let sk_bytes = hex::decode(&req.signing_key_hex)
-        .map_err(|_| (
+    let sk_bytes = hex::decode(&req.signing_key_hex).map_err(|_| {
+        (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: "Invalid signing key hex encoding".to_string(),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
-    let sk = SigningKey::from_bytes(&sk_bytes)
-        .map_err(|e| (
+    let sk = SigningKey::from_bytes(&sk_bytes).map_err(|e| {
+        (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: format!("Invalid signing key: {}", e),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
-    let subject: CapabilitySubject = serde_json::from_value(req.subject)
-        .map_err(|e| (
+    let subject: CapabilitySubject = serde_json::from_value(req.subject).map_err(|e| {
+        (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: format!("Invalid subject: {}", e),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
-    let constraints: Vec<Constraint> = req.constraints.iter()
+    let constraints: Vec<Constraint> = req
+        .constraints
+        .iter()
         .map(|v| serde_json::from_value(v.clone()))
         .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| (
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: format!("Invalid constraints: {}", e),
-                coherence_score: None,
-            })
-        ))?;
+        .map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!("Invalid constraints: {}", e),
+                    coherence_score: None,
+                }),
+            )
+        })?;
 
-    let cap = mgr.create_capability(
-        &req.issuer_did,
-        &sk,
-        subject,
-        constraints,
-        req.delegatable,
-    ).map_err(|e| (
-        StatusCode::INTERNAL_SERVER_ERROR,
-        Json(ErrorResponse {
-            error: format!("Failed to create capability: {}", e),
-            coherence_score: None,
-        })
-    ))?;
+    let cap = mgr
+        .create_capability(&req.issuer_did, &sk, subject, constraints, req.delegatable)
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("Failed to create capability: {}", e),
+                    coherence_score: None,
+                }),
+            )
+        })?;
 
     let cap_id_hex = hex::encode(cap.id);
-    let cap_json = serde_json::to_value(&cap)
-        .map_err(|e| (
+    let cap_json = serde_json::to_value(&cap).map_err(|e| {
+        (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
                 error: format!("Failed to serialize capability: {}", e),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
     Ok(Json(CreateCapabilityResponse {
         capability_id_hex: cap_id_hex,
@@ -285,14 +301,15 @@ pub async fn capability_delegate_handler(
 ) -> Result<Json<DelegateCapabilityResponse>, (StatusCode, Json<ErrorResponse>)> {
     let mut mgr = state.lock().await;
 
-    let cap_id_bytes = hex::decode(&req.capability_id_hex)
-        .map_err(|_| (
+    let cap_id_bytes = hex::decode(&req.capability_id_hex).map_err(|_| {
+        (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: "Invalid capability ID hex encoding".to_string(),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
     if cap_id_bytes.len() != 32 {
         return Err((
@@ -300,52 +317,54 @@ pub async fn capability_delegate_handler(
             Json(ErrorResponse {
                 error: "Capability ID must be 32 bytes".to_string(),
                 coherence_score: None,
-            })
+            }),
         ));
     }
 
     let mut cap_id = [0u8; 32];
     cap_id.copy_from_slice(&cap_id_bytes);
 
-    let sk_bytes = hex::decode(&req.delegator_sk_hex)
-        .map_err(|_| (
+    let sk_bytes = hex::decode(&req.delegator_sk_hex).map_err(|_| {
+        (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: "Invalid signing key hex encoding".to_string(),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
-    let sk = SigningKey::from_bytes(&sk_bytes)
-        .map_err(|e| (
+    let sk = SigningKey::from_bytes(&sk_bytes).map_err(|e| {
+        (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: format!("Invalid signing key: {}", e),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
-    let delegation = mgr.delegate_capability(
-        &cap_id,
-        &req.delegator_did,
-        &sk,
-        &req.delegatee_did,
-    ).map_err(|e| (
-        StatusCode::FORBIDDEN,
-        Json(ErrorResponse {
-            error: format!("Failed to delegate capability: {}", e),
-            coherence_score: None,
-        })
-    ))?;
+    let delegation = mgr
+        .delegate_capability(&cap_id, &req.delegator_did, &sk, &req.delegatee_did)
+        .map_err(|e| {
+            (
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse {
+                    error: format!("Failed to delegate capability: {}", e),
+                    coherence_score: None,
+                }),
+            )
+        })?;
 
-    let delegation_json = serde_json::to_value(&delegation)
-        .map_err(|e| (
+    let delegation_json = serde_json::to_value(&delegation).map_err(|e| {
+        (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
                 error: format!("Failed to serialize delegation: {}", e),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
     Ok(Json(DelegateCapabilityResponse {
         delegation: delegation_json,
@@ -370,14 +389,15 @@ pub async fn capability_invoke_handler(
 ) -> Result<Json<InvokeCapabilityResponse>, (StatusCode, Json<ErrorResponse>)> {
     let mgr = state.lock().await;
 
-    let cap_id_bytes = hex::decode(&req.capability_id_hex)
-        .map_err(|_| (
+    let cap_id_bytes = hex::decode(&req.capability_id_hex).map_err(|_| {
+        (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: "Invalid capability ID hex encoding".to_string(),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
     if cap_id_bytes.len() != 32 {
         return Err((
@@ -385,7 +405,7 @@ pub async fn capability_invoke_handler(
             Json(ErrorResponse {
                 error: "Capability ID must be 32 bytes".to_string(),
                 coherence_score: None,
-            })
+            }),
         ));
     }
 
@@ -402,14 +422,14 @@ pub async fn capability_invoke_handler(
             Json(ErrorResponse {
                 error: "Capability invocation not permitted".to_string(),
                 coherence_score: None,
-            })
+            }),
         )),
         Err(e) => Err((
             StatusCode::FORBIDDEN,
             Json(ErrorResponse {
                 error: format!("Failed to invoke capability: {}", e),
                 coherence_score: None,
-            })
+            }),
         )),
     }
 }
@@ -427,14 +447,15 @@ pub async fn capability_revoke_handler(
 ) -> Result<Json<SuccessResponse>, (StatusCode, Json<ErrorResponse>)> {
     let mut mgr = state.lock().await;
 
-    let cap_id_bytes = hex::decode(&req.capability_id_hex)
-        .map_err(|_| (
+    let cap_id_bytes = hex::decode(&req.capability_id_hex).map_err(|_| {
+        (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: "Invalid capability ID hex encoding".to_string(),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
     if cap_id_bytes.len() != 32 {
         return Err((
@@ -442,7 +463,7 @@ pub async fn capability_revoke_handler(
             Json(ErrorResponse {
                 error: "Capability ID must be 32 bytes".to_string(),
                 coherence_score: None,
-            })
+            }),
         ));
     }
 
@@ -453,23 +474,30 @@ pub async fn capability_revoke_handler(
         "single" => RevocationScope::Single,
         "subtree" => RevocationScope::Subtree,
         "all" => RevocationScope::All,
-        _ => return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: format!("Invalid scope: must be 'single', 'subtree', or 'all', got '{}'", req.scope),
-                coherence_score: None,
-            })
-        )),
+        _ => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!(
+                        "Invalid scope: must be 'single', 'subtree', or 'all', got '{}'",
+                        req.scope
+                    ),
+                    coherence_score: None,
+                }),
+            ))
+        }
     };
 
     mgr.revoke_capability(&cap_id, &req.revoker_did, scope)
-        .map_err(|e| (
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse {
-                error: format!("Failed to revoke capability: {}", e),
-                coherence_score: None,
-            })
-        ))?;
+        .map_err(|e| {
+            (
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse {
+                    error: format!("Failed to revoke capability: {}", e),
+                    coherence_score: None,
+                }),
+            )
+        })?;
 
     Ok(Json(SuccessResponse { success: true }))
 }
@@ -485,14 +513,15 @@ pub async fn capability_get_handler(
 ) -> Result<Json<GetCapabilityResponse>, (StatusCode, Json<ErrorResponse>)> {
     let mgr = state.lock().await;
 
-    let cap_id_bytes = hex::decode(&cap_id_hex)
-        .map_err(|_| (
+    let cap_id_bytes = hex::decode(&cap_id_hex).map_err(|_| {
+        (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: "Invalid capability ID hex encoding".to_string(),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
     if cap_id_bytes.len() != 32 {
         return Err((
@@ -500,30 +529,32 @@ pub async fn capability_get_handler(
             Json(ErrorResponse {
                 error: "Capability ID must be 32 bytes".to_string(),
                 coherence_score: None,
-            })
+            }),
         ));
     }
 
     let mut cap_id = [0u8; 32];
     cap_id.copy_from_slice(&cap_id_bytes);
 
-    let cap = mgr.get_capability(&cap_id)
-        .ok_or_else(|| (
+    let cap = mgr.get_capability(&cap_id).ok_or_else(|| {
+        (
             StatusCode::NOT_FOUND,
             Json(ErrorResponse {
                 error: format!("Capability not found: {}", cap_id_hex),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
-    let cap_json = serde_json::to_value(cap)
-        .map_err(|e| (
+    let cap_json = serde_json::to_value(cap).map_err(|e| {
+        (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
                 error: format!("Failed to serialize capability: {}", e),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
     Ok(Json(GetCapabilityResponse {
         capability: cap_json,
@@ -543,16 +574,19 @@ pub async fn capability_list_by_did_handler(
 
     let caps = mgr.list_capabilities_for_did(&did);
 
-    let caps_json: Vec<serde_json::Value> = caps.iter()
+    let caps_json: Vec<serde_json::Value> = caps
+        .iter()
         .map(serde_json::to_value)
         .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: format!("Failed to serialize capabilities: {}", e),
-                coherence_score: None,
-            })
-        ))?;
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("Failed to serialize capabilities: {}", e),
+                    coherence_score: None,
+                }),
+            )
+        })?;
 
     Ok(Json(ListCapabilitiesResponse {
         capabilities: caps_json,
@@ -575,32 +609,41 @@ pub async fn introduction_create_handler(
 ) -> Result<Json<SuccessResponse>, (StatusCode, Json<ErrorResponse>)> {
     let mut mgr = state.lock().await;
 
-    let sk_bytes = hex::decode(&req.introducer_sk_hex)
-        .map_err(|_| (
+    let sk_bytes = hex::decode(&req.introducer_sk_hex).map_err(|_| {
+        (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: "Invalid signing key hex encoding".to_string(),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
-    let sk = SigningKey::from_bytes(&sk_bytes)
-        .map_err(|e| (
+    let sk = SigningKey::from_bytes(&sk_bytes).map_err(|e| {
+        (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: format!("Invalid signing key: {}", e),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
-    mgr.introduce(&req.introducer_did, &sk, &req.introduced_did, &req.edge_name)
-        .map_err(|e| (
+    mgr.introduce(
+        &req.introducer_did,
+        &sk,
+        &req.introduced_did,
+        &req.edge_name,
+    )
+    .map_err(|e| {
+        (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
                 error: format!("Failed to create introduction: {}", e),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
     Ok(Json(SuccessResponse { success: true }))
 }
@@ -616,7 +659,8 @@ pub async fn introduction_chain_handler(
 ) -> Json<IntroductionChainResponse> {
     let mgr = state.lock().await;
 
-    let chain = mgr.get_introduction_chain(&from_did, &to_did)
+    let chain = mgr
+        .get_introduction_chain(&from_did, &to_did)
         .unwrap_or_else(|| vec![from_did.clone(), to_did.clone()]);
 
     Json(IntroductionChainResponse { chain })
@@ -635,23 +679,25 @@ pub async fn coherence_profile_handler(
 ) -> Result<Json<CoherenceProfileResponse>, (StatusCode, Json<ErrorResponse>)> {
     let mgr = state.lock().await;
 
-    let profile = mgr.get_coherence_profile(&did)
-        .ok_or_else(|| (
+    let profile = mgr.get_coherence_profile(&did).ok_or_else(|| {
+        (
             StatusCode::NOT_FOUND,
             Json(ErrorResponse {
                 error: format!("DID not found: {}", did),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
-    let profile_json = serde_json::to_value(&profile)
-        .map_err(|e| (
+    let profile_json = serde_json::to_value(&profile).map_err(|e| {
+        (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
                 error: format!("Failed to serialize profile: {}", e),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
     Ok(Json(CoherenceProfileResponse {
         profile: profile_json,
@@ -669,18 +715,17 @@ pub async fn coherence_curvature_handler(
 ) -> Result<Json<CurvatureResponse>, (StatusCode, Json<ErrorResponse>)> {
     let mgr = state.lock().await;
 
-    let curvature = mgr.get_identity_curvature(&did_a, &did_b)
-        .ok_or_else(|| (
+    let curvature = mgr.get_identity_curvature(&did_a, &did_b).ok_or_else(|| {
+        (
             StatusCode::NOT_FOUND,
             Json(ErrorResponse {
                 error: "One or both DIDs not found".to_string(),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
-    Ok(Json(CurvatureResponse {
-        curvature,
-    }))
+    Ok(Json(CurvatureResponse { curvature }))
 }
 
 #[derive(Serialize)]
@@ -713,14 +758,15 @@ pub async fn petname_set_handler(
 ) -> Result<Json<SuccessResponse>, (StatusCode, Json<ErrorResponse>)> {
     let mut mgr = state.lock().await;
 
-    mgr.set_petname(&req.name, &req.did)
-        .map_err(|e| (
+    mgr.set_petname(&req.name, &req.did).map_err(|e| {
+        (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
                 error: format!("Failed to set petname: {}", e),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
     Ok(Json(SuccessResponse { success: true }))
 }
@@ -736,18 +782,17 @@ pub async fn petname_resolve_handler(
 ) -> Result<Json<ResolvePetnameResponse>, (StatusCode, Json<ErrorResponse>)> {
     let mgr = state.lock().await;
 
-    let did = mgr.resolve_petname(&name)
-        .ok_or_else(|| (
+    let did = mgr.resolve_petname(&name).ok_or_else(|| {
+        (
             StatusCode::NOT_FOUND,
             Json(ErrorResponse {
                 error: format!("Petname not found: {}", name),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
-    Ok(Json(ResolvePetnameResponse {
-        did,
-    }))
+    Ok(Json(ResolvePetnameResponse { did }))
 }
 
 // Governance endpoints
@@ -775,78 +820,93 @@ pub async fn governance_propose_handler(
 ) -> Result<Json<CreateProposalResponse>, (StatusCode, Json<ErrorResponse>)> {
     let mut mgr = state.lock().await;
 
-    let sk_bytes = hex::decode(&req.proposer_sk_hex)
-        .map_err(|_| (
+    let sk_bytes = hex::decode(&req.proposer_sk_hex).map_err(|_| {
+        (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: "Invalid signing key hex encoding".to_string(),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
-    let sk = SigningKey::from_bytes(&sk_bytes)
-        .map_err(|e| (
+    let sk = SigningKey::from_bytes(&sk_bytes).map_err(|e| {
+        (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: format!("Invalid signing key: {}", e),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
     // Parse proposal type
     let proposal_type = match req.proposal_type.to_lowercase().as_str() {
         "protocol_parameter" => {
-            let param = req.parameter.ok_or_else(|| (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse {
-                    error: "Missing parameter field for protocol_parameter proposal".to_string(),
-                    coherence_score: None,
-                })
-            ))?;
-            let value = req.new_value.ok_or_else(|| (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse {
-                    error: "Missing new_value field for protocol_parameter proposal".to_string(),
-                    coherence_score: None,
-                })
-            ))?;
+            let param = req.parameter.ok_or_else(|| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorResponse {
+                        error: "Missing parameter field for protocol_parameter proposal"
+                            .to_string(),
+                        coherence_score: None,
+                    }),
+                )
+            })?;
+            let value = req.new_value.ok_or_else(|| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorResponse {
+                        error: "Missing new_value field for protocol_parameter proposal"
+                            .to_string(),
+                        coherence_score: None,
+                    }),
+                )
+            })?;
             ProposalType::ProtocolParameter {
                 parameter: param,
                 new_value: value.into_bytes(),
             }
         }
-        _ => return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: format!("Unsupported proposal type: {}", req.proposal_type),
-                coherence_score: None,
-            })
-        )),
+        _ => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!("Unsupported proposal type: {}", req.proposal_type),
+                    coherence_score: None,
+                }),
+            ))
+        }
     };
 
-    let proposal = mgr.create_proposal(
-        &req.proposer_did,
-        &sk,
-        proposal_type,
-        &req.description,
-        req.duration_blocks,
-    ).map_err(|e| (
-        StatusCode::INTERNAL_SERVER_ERROR,
-        Json(ErrorResponse {
-            error: format!("Failed to create proposal: {}", e),
-            coherence_score: None,
-        })
-    ))?;
+    let proposal = mgr
+        .create_proposal(
+            &req.proposer_did,
+            &sk,
+            proposal_type,
+            &req.description,
+            req.duration_blocks,
+        )
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("Failed to create proposal: {}", e),
+                    coherence_score: None,
+                }),
+            )
+        })?;
 
     let proposal_id_hex = hex::encode(proposal.id);
-    let proposal_json = serde_json::to_value(&proposal)
-        .map_err(|e| (
+    let proposal_json = serde_json::to_value(&proposal).map_err(|e| {
+        (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
                 error: format!("Failed to serialize proposal: {}", e),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
     Ok(Json(CreateProposalResponse {
         proposal_id_hex,
@@ -873,14 +933,15 @@ pub async fn governance_vote_handler(
 ) -> Result<Json<CastVoteResponse>, (StatusCode, Json<ErrorResponse>)> {
     let mut mgr = state.lock().await;
 
-    let proposal_id_bytes = hex::decode(&req.proposal_id_hex)
-        .map_err(|_| (
+    let proposal_id_bytes = hex::decode(&req.proposal_id_hex).map_err(|_| {
+        (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: "Invalid proposal ID hex encoding".to_string(),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
     if proposal_id_bytes.len() != 32 {
         return Err((
@@ -888,59 +949,67 @@ pub async fn governance_vote_handler(
             Json(ErrorResponse {
                 error: "Proposal ID must be 32 bytes".to_string(),
                 coherence_score: None,
-            })
+            }),
         ));
     }
 
     let mut proposal_id = [0u8; 32];
     proposal_id.copy_from_slice(&proposal_id_bytes);
 
-    let sk_bytes = hex::decode(&req.voter_sk_hex)
-        .map_err(|_| (
+    let sk_bytes = hex::decode(&req.voter_sk_hex).map_err(|_| {
+        (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: "Invalid signing key hex encoding".to_string(),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
-    let sk = SigningKey::from_bytes(&sk_bytes)
-        .map_err(|e| (
+    let sk = SigningKey::from_bytes(&sk_bytes).map_err(|e| {
+        (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: format!("Invalid signing key: {}", e),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
     let vote_choice = match req.vote.to_lowercase().as_str() {
         "for" => VoteChoice::For,
         "against" => VoteChoice::Against,
         "abstain" => VoteChoice::Abstain,
-        _ => return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: format!("Invalid vote: must be 'for', 'against', or 'abstain', got '{}'", req.vote),
-                coherence_score: None,
-            })
-        )),
+        _ => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!(
+                        "Invalid vote: must be 'for', 'against', or 'abstain', got '{}'",
+                        req.vote
+                    ),
+                    coherence_score: None,
+                }),
+            ))
+        }
     };
 
-    let vote = mgr.cast_vote(&proposal_id, &req.voter_did, &sk, vote_choice)
-        .map_err(|e| (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: format!("Failed to cast vote: {}", e),
-                coherence_score: None,
-            })
-        ))?;
+    let vote = mgr
+        .cast_vote(&proposal_id, &req.voter_did, &sk, vote_choice)
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("Failed to cast vote: {}", e),
+                    coherence_score: None,
+                }),
+            )
+        })?;
 
     let vote_id = vote.compute_id();
     let vote_id_hex = hex::encode(vote_id);
 
-    Ok(Json(CastVoteResponse {
-        vote_id_hex,
-    }))
+    Ok(Json(CastVoteResponse { vote_id_hex }))
 }
 
 #[derive(Serialize)]
@@ -954,16 +1023,19 @@ pub async fn governance_list_proposals_handler(
     let mgr = state.lock().await;
 
     let proposals = mgr.list_proposals();
-    let proposals_json: Vec<serde_json::Value> = proposals.iter()
+    let proposals_json: Vec<serde_json::Value> = proposals
+        .iter()
         .map(serde_json::to_value)
         .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: format!("Failed to serialize proposals: {}", e),
-                coherence_score: None,
-            })
-        ))?;
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("Failed to serialize proposals: {}", e),
+                    coherence_score: None,
+                }),
+            )
+        })?;
 
     Ok(Json(ListProposalsResponse {
         proposals: proposals_json,
@@ -982,14 +1054,15 @@ pub async fn governance_get_proposal_handler(
 ) -> Result<Json<GetProposalResponse>, (StatusCode, Json<ErrorResponse>)> {
     let mgr = state.lock().await;
 
-    let proposal_id_bytes = hex::decode(&proposal_id_hex)
-        .map_err(|_| (
+    let proposal_id_bytes = hex::decode(&proposal_id_hex).map_err(|_| {
+        (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
                 error: "Invalid proposal ID hex encoding".to_string(),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
     if proposal_id_bytes.len() != 32 {
         return Err((
@@ -997,23 +1070,25 @@ pub async fn governance_get_proposal_handler(
             Json(ErrorResponse {
                 error: "Proposal ID must be 32 bytes".to_string(),
                 coherence_score: None,
-            })
+            }),
         ));
     }
 
     let mut proposal_id = [0u8; 32];
     proposal_id.copy_from_slice(&proposal_id_bytes);
 
-    let proposal = mgr.get_proposal(&proposal_id)
-        .ok_or_else(|| (
+    let proposal = mgr.get_proposal(&proposal_id).ok_or_else(|| {
+        (
             StatusCode::NOT_FOUND,
             Json(ErrorResponse {
                 error: format!("Proposal not found: {}", proposal_id_hex),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
-    let result = mgr.evaluate_proposal(&proposal_id)
+    let result = mgr
+        .evaluate_proposal(&proposal_id)
         .unwrap_or(disentangle_identity::ProposalResult::Pending);
 
     let result_str = match result {
@@ -1022,14 +1097,15 @@ pub async fn governance_get_proposal_handler(
         disentangle_identity::ProposalResult::Pending => "pending",
     };
 
-    let proposal_json = serde_json::to_value(proposal)
-        .map_err(|e| (
+    let proposal_json = serde_json::to_value(proposal).map_err(|e| {
+        (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
                 error: format!("Failed to serialize proposal: {}", e),
                 coherence_score: None,
-            })
-        ))?;
+            }),
+        )
+    })?;
 
     Ok(Json(GetProposalResponse {
         proposal: proposal_json,

--- a/disentangle-node/src/identity_state.rs
+++ b/disentangle-node/src/identity_state.rs
@@ -3,20 +3,17 @@
 //! Manages DID lifecycle, capability operations, introductions, coherence tracking,
 //! and petnames for the Disentangle Protocol.
 
+use disentangle_crypto::hash::{sha3_256, Hash256};
+use disentangle_crypto::signature::{generate_keypair, SigningKey, VerifyingKey};
 use disentangle_identity::{
-    DID, DIDDocument, AgentType, IdentityError,
-    Capability, CapabilityId, CapabilitySubject, Constraint, DelegationRecord, RevocationScope,
-    IntroductionTransaction, IntroductionContext,
-    IdentityGraph, CoherenceProfile, PetnameDB,
-    ConstraintContext,
-    GovernanceProposal, GovernanceVote, ProposalType, VoteChoice, ProposalResult,
-    evaluate_proposal,
+    evaluate_proposal, AgentType, Capability, CapabilityId, CapabilitySubject, CoherenceProfile,
+    Constraint, ConstraintContext, DIDDocument, DelegationRecord, GovernanceProposal,
+    GovernanceVote, IdentityError, IdentityGraph, IntroductionContext, IntroductionTransaction,
+    PetnameDB, ProposalResult, ProposalType, RevocationScope, VoteChoice, DID,
 };
-use disentangle_crypto::signature::{SigningKey, VerifyingKey, generate_keypair};
-use disentangle_crypto::hash::{Hash256, sha3_256};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
-use serde::{Serialize, Deserialize};
 
 /// Serializable state for persistence
 #[derive(Serialize, Deserialize)]
@@ -71,7 +68,10 @@ impl IdentityStateManager {
     // DID Operations
 
     /// Register a new DID with the specified agent type
-    pub fn register_did(&mut self, agent_type: AgentType) -> Result<(DID, DIDDocument, SigningKey), IdentityError> {
+    pub fn register_did(
+        &mut self,
+        agent_type: AgentType,
+    ) -> Result<(DID, DIDDocument, SigningKey), IdentityError> {
         let (sk, pk) = generate_keypair();
 
         let is_agi = matches!(agent_type, AgentType::AGI { .. });
@@ -79,7 +79,9 @@ impl IdentityStateManager {
 
         // Prevent duplicate DIDs
         if self.did_registry.contains_key(&did.0) {
-            return Err(IdentityError::InvalidDID("DID already registered".to_string()));
+            return Err(IdentityError::InvalidDID(
+                "DID already registered".to_string(),
+            ));
         }
 
         let doc = DIDDocument::new(&sk, &pk, agent_type, self.current_depth);
@@ -88,7 +90,8 @@ impl IdentityStateManager {
         self.first_seen.insert(did.0.clone(), self.current_depth);
 
         // Store in registry
-        self.did_registry.insert(did.0.clone(), (doc.clone(), pk.clone()));
+        self.did_registry
+            .insert(did.0.clone(), (doc.clone(), pk.clone()));
 
         Ok((did, doc, sk))
     }
@@ -127,7 +130,9 @@ impl IdentityStateManager {
         constraints: Vec<Constraint>,
         delegatable: bool,
     ) -> Result<Capability, IdentityError> {
-        let (_, issuer_pk) = self.did_registry.get(issuer_did)
+        let (_, issuer_pk) = self
+            .did_registry
+            .get(issuer_did)
             .ok_or_else(|| IdentityError::DIDNotFound(issuer_did.to_string()))?;
 
         let did = DID(issuer_did.to_string());
@@ -153,7 +158,9 @@ impl IdentityStateManager {
         delegator_sk: &SigningKey,
         delegatee_did: &str,
     ) -> Result<DelegationRecord, IdentityError> {
-        let cap = self.capability_store.get(cap_id)
+        let cap = self
+            .capability_store
+            .get(cap_id)
             .ok_or_else(|| IdentityError::CapabilityNotFound(hex::encode(cap_id)))?;
 
         // Check if capability is revoked
@@ -164,10 +171,20 @@ impl IdentityStateManager {
         let delegator = DID(delegator_did.to_string());
         let delegatee = DID(delegatee_did.to_string());
 
-        let mut record = DelegationRecord::new(cap, &delegator, &delegatee, delegator_sk, self.current_depth)?;
+        let mut record = DelegationRecord::new(
+            cap,
+            &delegator,
+            &delegatee,
+            delegator_sk,
+            self.current_depth,
+        )?;
 
         // Calculate depth from existing chain
-        let existing_chain = self.delegation_chains.get(cap_id).map(|v| v.as_slice()).unwrap_or(&[]);
+        let existing_chain = self
+            .delegation_chains
+            .get(cap_id)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[]);
         record.depth = (existing_chain.len() as u32 + 1) as u64;
 
         // Check depth limit
@@ -179,7 +196,8 @@ impl IdentityStateManager {
         }
 
         // Store delegation
-        self.delegation_chains.entry(*cap_id)
+        self.delegation_chains
+            .entry(*cap_id)
             .or_default()
             .push(record.clone());
 
@@ -190,8 +208,14 @@ impl IdentityStateManager {
     }
 
     /// Invoke a capability (check if invoker has permission)
-    pub fn invoke_capability(&self, cap_id: &CapabilityId, invoker_did: &str) -> Result<bool, IdentityError> {
-        let cap = self.capability_store.get(cap_id)
+    pub fn invoke_capability(
+        &self,
+        cap_id: &CapabilityId,
+        invoker_did: &str,
+    ) -> Result<bool, IdentityError> {
+        let cap = self
+            .capability_store
+            .get(cap_id)
             .ok_or_else(|| IdentityError::CapabilityNotFound(hex::encode(cap_id)))?;
 
         // Check if revoked
@@ -211,13 +235,20 @@ impl IdentityStateManager {
             .unwrap_or(false);
 
         if !is_delegatee {
-            return Err(IdentityError::ConstraintNotSatisfied("Not in delegation chain".to_string()));
+            return Err(IdentityError::ConstraintNotSatisfied(
+                "Not in delegation chain".to_string(),
+            ));
         }
 
         // Build constraint context
         let invoker = DID(invoker_did.to_string());
         let first_seen_depth = self.first_seen.get(invoker_did).copied().unwrap_or(0);
-        let coherence_profile = CoherenceProfile::compute(&invoker, &self.identity_graph, first_seen_depth, self.current_depth);
+        let coherence_profile = CoherenceProfile::compute(
+            &invoker,
+            &self.identity_graph,
+            first_seen_depth,
+            self.current_depth,
+        );
 
         let context = ConstraintContext {
             current_depth: self.current_depth,
@@ -229,7 +260,9 @@ impl IdentityStateManager {
 
         // Check all constraints
         if !cap.check_constraints(&context) {
-            return Err(IdentityError::ConstraintNotSatisfied("Capability constraints not met".to_string()));
+            return Err(IdentityError::ConstraintNotSatisfied(
+                "Capability constraints not met".to_string(),
+            ));
         }
 
         Ok(true)
@@ -242,12 +275,16 @@ impl IdentityStateManager {
         revoker_did: &str,
         scope: RevocationScope,
     ) -> Result<(), IdentityError> {
-        let cap = self.capability_store.get(cap_id)
+        let cap = self
+            .capability_store
+            .get(cap_id)
             .ok_or_else(|| IdentityError::CapabilityNotFound(hex::encode(cap_id)))?;
 
         // Only issuer can revoke
         if cap.issuer.0 != revoker_did {
-            return Err(IdentityError::ConstraintNotSatisfied("Only issuer can revoke".to_string()));
+            return Err(IdentityError::ConstraintNotSatisfied(
+                "Only issuer can revoke".to_string(),
+            ));
         }
 
         self.identity_graph.record_revocation(cap_id, scope);
@@ -325,7 +362,12 @@ impl IdentityStateManager {
         let did_obj = DID(did.to_string());
         let first_seen_depth = self.first_seen.get(did).copied().unwrap_or(0);
 
-        Some(CoherenceProfile::compute(&did_obj, &self.identity_graph, first_seen_depth, self.current_depth))
+        Some(CoherenceProfile::compute(
+            &did_obj,
+            &self.identity_graph,
+            first_seen_depth,
+            self.current_depth,
+        ))
     }
 
     /// Get identity curvature between two DIDs
@@ -333,7 +375,9 @@ impl IdentityStateManager {
         let did_a_obj = DID(did_a.to_string());
         let did_b_obj = DID(did_b.to_string());
 
-        let curvature_fp = self.identity_graph.identity_curvature(&did_a_obj, &did_b_obj);
+        let curvature_fp = self
+            .identity_graph
+            .identity_curvature(&did_a_obj, &did_b_obj);
 
         // Convert from fixed-point to f64
         use disentangle_dag::SCALE;
@@ -343,7 +387,8 @@ impl IdentityStateManager {
     /// Get neighbors of a DID
     pub fn get_neighbors(&self, did: &str) -> Vec<String> {
         let did_obj = DID(did.to_string());
-        self.identity_graph.neighbors(&did_obj)
+        self.identity_graph
+            .neighbors(&did_obj)
             .into_iter()
             .map(|d| d.0)
             .collect()
@@ -384,7 +429,8 @@ impl IdentityStateManager {
     /// Set a petname for a DID
     pub fn set_petname(&mut self, name: &str, did: &str) -> Result<(), IdentityError> {
         let did_obj = DID(did.to_string());
-        self.petnames.bind(name, &did_obj, vec![], self.current_depth)
+        self.petnames
+            .bind(name, &did_obj, vec![], self.current_depth)
     }
 
     /// Resolve a petname to a DID
@@ -404,7 +450,9 @@ impl IdentityStateManager {
         duration_blocks: u64,
     ) -> Result<GovernanceProposal, IdentityError> {
         // Verify proposer exists
-        let (_, proposer_pk) = self.did_registry.get(proposer_did)
+        let (_, proposer_pk) = self
+            .did_registry
+            .get(proposer_did)
             .ok_or_else(|| IdentityError::DIDNotFound(proposer_did.to_string()))?;
 
         let proposer = DID(proposer_did.to_string());
@@ -431,7 +479,9 @@ impl IdentityStateManager {
 
         // Verify the proposal signature
         if !proposal.verify(proposer_pk) {
-            return Err(IdentityError::InvalidDID("Invalid proposal signature".to_string()));
+            return Err(IdentityError::InvalidDID(
+                "Invalid proposal signature".to_string(),
+            ));
         }
 
         self.proposals.insert(proposal.id, proposal.clone());
@@ -448,25 +498,29 @@ impl IdentityStateManager {
         vote: VoteChoice,
     ) -> Result<GovernanceVote, IdentityError> {
         // Verify proposal exists
-        let proposal = self.proposals.get(proposal_id)
+        let proposal = self
+            .proposals
+            .get(proposal_id)
             .ok_or_else(|| IdentityError::CapabilityNotFound(hex::encode(proposal_id)))?;
 
         // Verify voter exists
-        let (_, voter_pk) = self.did_registry.get(voter_did)
+        let (_, voter_pk) = self
+            .did_registry
+            .get(voter_did)
             .ok_or_else(|| IdentityError::DIDNotFound(voter_did.to_string()))?;
 
         // Check voting window
         if self.current_depth < proposal.voting_start || self.current_depth > proposal.voting_end {
             return Err(IdentityError::ConstraintNotSatisfied(
-                "Voting period not active".to_string()
+                "Voting period not active".to_string(),
             ));
         }
 
         // Create vote transaction identity
         // For Phase 1, we use the voter's public key as ephemeral_pk (placeholder)
         // In Phase 2, this would use ZK proofs
-        use disentangle_identity::TransactionIdentity;
         use disentangle_crypto::types::Nullifier;
+        use disentangle_identity::TransactionIdentity;
 
         let voter_identity = TransactionIdentity {
             ephemeral_pk: voter_pk.clone(),
@@ -507,11 +561,21 @@ impl IdentityStateManager {
         for did_str in self.did_registry.keys() {
             let did = DID(did_str.clone());
             let first_seen_depth = self.first_seen.get(did_str).copied().unwrap_or(0);
-            let profile = CoherenceProfile::compute(&did, &self.identity_graph, first_seen_depth, self.current_depth);
+            let profile = CoherenceProfile::compute(
+                &did,
+                &self.identity_graph,
+                first_seen_depth,
+                self.current_depth,
+            );
             profiles.insert(did, profile);
         }
 
-        Some(evaluate_proposal(proposal, &self.votes, &profiles, self.current_depth))
+        Some(evaluate_proposal(
+            proposal,
+            &self.votes,
+            &profiles,
+            self.current_depth,
+        ))
     }
 
     // Persistence Operations
@@ -531,7 +595,8 @@ impl IdentityStateManager {
 
         let capabilities: Vec<Capability> = self.capability_store.values().cloned().collect();
 
-        let delegations: Vec<(String, Vec<DelegationRecord>)> = self.delegation_chains
+        let delegations: Vec<(String, Vec<DelegationRecord>)> = self
+            .delegation_chains
             .iter()
             .map(|(cap_id, chain)| (hex::encode(cap_id), chain.clone()))
             .collect();
@@ -577,8 +642,9 @@ impl IdentityStateManager {
             let doc = &state.did_documents[i];
             let vk_bytes = hex::decode(&state.verifying_keys_hex[i])
                 .map_err(|_| IdentityError::InvalidDID("Invalid verifying key hex".to_string()))?;
-            let vk = VerifyingKey::from_bytes(&vk_bytes)
-                .map_err(|_| IdentityError::InvalidDID("Invalid verifying key bytes".to_string()))?;
+            let vk = VerifyingKey::from_bytes(&vk_bytes).map_err(|_| {
+                IdentityError::InvalidDID("Invalid verifying key bytes".to_string())
+            })?;
             did_registry.insert(key.clone(), (doc.clone(), vk));
         }
 
@@ -594,7 +660,9 @@ impl IdentityStateManager {
             let cap_id_bytes = hex::decode(&cap_id_hex)
                 .map_err(|_| IdentityError::InvalidDID("Invalid capability ID".to_string()))?;
             if cap_id_bytes.len() != 32 {
-                return Err(IdentityError::InvalidDID("Capability ID must be 32 bytes".to_string()));
+                return Err(IdentityError::InvalidDID(
+                    "Capability ID must be 32 bytes".to_string(),
+                ));
             }
             let mut cap_id = [0u8; 32];
             cap_id.copy_from_slice(&cap_id_bytes);
@@ -668,7 +736,9 @@ mod tests {
     #[test]
     fn test_register_agi_did() {
         let mut manager = IdentityStateManager::new();
-        let result = manager.register_did(AgentType::AGI { runtime_attestation: None });
+        let result = manager.register_did(AgentType::AGI {
+            runtime_attestation: None,
+        });
 
         assert!(result.is_ok());
         let (did, doc, _sk) = result.unwrap();
@@ -710,13 +780,7 @@ mod tests {
             scope: TransactionScope::All,
         };
 
-        let result = manager.create_capability(
-            &did.0,
-            &sk,
-            subject,
-            vec![],
-            true,
-        );
+        let result = manager.create_capability(&did.0, &sk, subject, vec![], true);
 
         assert!(result.is_ok());
         let cap = result.unwrap();
@@ -733,21 +797,21 @@ mod tests {
         let (delegatee_did, _doc2, _sk2) = manager.register_did(AgentType::Human).unwrap();
 
         // Create capability
-        let cap = manager.create_capability(
-            &issuer_did.0,
-            &issuer_sk,
-            CapabilitySubject::Transact { scope: TransactionScope::All },
-            vec![],
-            true,
-        ).unwrap();
+        let cap = manager
+            .create_capability(
+                &issuer_did.0,
+                &issuer_sk,
+                CapabilitySubject::Transact {
+                    scope: TransactionScope::All,
+                },
+                vec![],
+                true,
+            )
+            .unwrap();
 
         // Delegate
-        let result = manager.delegate_capability(
-            &cap.id,
-            &issuer_did.0,
-            &issuer_sk,
-            &delegatee_did.0,
-        );
+        let result =
+            manager.delegate_capability(&cap.id, &issuer_did.0, &issuer_sk, &delegatee_did.0);
 
         assert!(result.is_ok());
         let delegation = result.unwrap();
@@ -766,13 +830,17 @@ mod tests {
         let (did_c, _, _sk_c) = manager.register_did(AgentType::Human).unwrap();
 
         // Create capability with max depth 2
-        let mut cap = manager.create_capability(
-            &did_a.0,
-            &sk_a,
-            CapabilitySubject::Transact { scope: TransactionScope::All },
-            vec![],
-            true,
-        ).unwrap();
+        let mut cap = manager
+            .create_capability(
+                &did_a.0,
+                &sk_a,
+                CapabilitySubject::Transact {
+                    scope: TransactionScope::All,
+                },
+                vec![],
+                true,
+            )
+            .unwrap();
         cap.max_delegation_depth = 2;
         manager.capability_store.insert(cap.id, cap.clone());
 
@@ -798,13 +866,17 @@ mod tests {
 
         let (issuer_did, _, issuer_sk) = manager.register_did(AgentType::Human).unwrap();
 
-        let cap = manager.create_capability(
-            &issuer_did.0,
-            &issuer_sk,
-            CapabilitySubject::Transact { scope: TransactionScope::All },
-            vec![],
-            true,
-        ).unwrap();
+        let cap = manager
+            .create_capability(
+                &issuer_did.0,
+                &issuer_sk,
+                CapabilitySubject::Transact {
+                    scope: TransactionScope::All,
+                },
+                vec![],
+                true,
+            )
+            .unwrap();
 
         // Revoke
         let result = manager.revoke_capability(&cap.id, &issuer_did.0, RevocationScope::Single);
@@ -852,7 +924,10 @@ mod tests {
         // A and B share C and D as neighbors
         let curvature = manager.get_identity_curvature(&did_a.0, &did_b.0);
         assert!(curvature.is_some());
-        assert!(curvature.unwrap() > 0.0, "Expected positive curvature with shared neighbors");
+        assert!(
+            curvature.unwrap() > 0.0,
+            "Expected positive curvature with shared neighbors"
+        );
     }
 
     #[test]
@@ -868,7 +943,10 @@ mod tests {
         // No shared neighbors beyond each other -> negative curvature
         let curvature = manager.get_identity_curvature(&did_a.0, &did_b.0);
         assert!(curvature.is_some());
-        assert!(curvature.unwrap() < 0.0, "Expected negative curvature with no shared neighbors");
+        assert!(
+            curvature.unwrap() < 0.0,
+            "Expected negative curvature with no shared neighbors"
+        );
     }
 
     #[test]
@@ -900,7 +978,10 @@ mod tests {
         assert!(profile2.is_some());
         let mass2 = profile2.unwrap().topological_mass;
 
-        assert!(mass2 > mass1, "Topological mass should increase with more introductions");
+        assert!(
+            mass2 > mass1,
+            "Topological mass should increase with more introductions"
+        );
     }
 
     #[test]
@@ -923,15 +1004,22 @@ mod tests {
 
         // Mass should decay over time (20,000 depths = 2 half-lives)
         // Expected decay: initial_mass >> 2 = initial_mass / 4
-        assert!(decayed_mass < initial_mass,
+        assert!(
+            decayed_mass < initial_mass,
             "Coherence should decay over time: initial={}, decayed={}",
-            initial_mass, decayed_mass);
+            initial_mass,
+            decayed_mass
+        );
 
         // Should be roughly 1/4 of initial (2 half-lives)
         let expected_approx = initial_mass / 4;
         let tolerance = initial_mass / 10; // 10% tolerance
-        assert!((decayed_mass as i64 - expected_approx as i64).abs() < tolerance as i64,
-            "Decayed mass {} should be close to expected {}", decayed_mass, expected_approx);
+        assert!(
+            (decayed_mass as i64 - expected_approx as i64).abs() < tolerance as i64,
+            "Decayed mass {} should be close to expected {}",
+            decayed_mass,
+            expected_approx
+        );
     }
 
     #[test]
@@ -963,7 +1051,7 @@ mod tests {
 
         // Connect honest agents in a mesh (each knows multiple others)
         for i in 0..honest_agents.len() {
-            for j in (i+1)..honest_agents.len() {
+            for j in (i + 1)..honest_agents.len() {
                 if i != j {
                     let (ref did_i, ref sk_i) = honest_agents[i];
                     let (ref did_j, _) = honest_agents[j];
@@ -986,17 +1074,21 @@ mod tests {
         }
 
         // Compute average coherence for honest vs Sybil
-        let honest_coherence: Vec<i32> = honest_agents.iter()
+        let honest_coherence: Vec<i32> = honest_agents
+            .iter()
             .map(|(did, _)| {
-                manager.get_coherence_profile(&did.0)
+                manager
+                    .get_coherence_profile(&did.0)
                     .map(|p| p.topological_mass)
                     .unwrap_or(0)
             })
             .collect();
 
-        let sybil_coherence: Vec<i32> = sybil_agents.iter()
+        let sybil_coherence: Vec<i32> = sybil_agents
+            .iter()
             .map(|did| {
-                manager.get_coherence_profile(&did.0)
+                manager
+                    .get_coherence_profile(&did.0)
                     .map(|p| p.topological_mass)
                     .unwrap_or(0)
             })
@@ -1006,8 +1098,11 @@ mod tests {
         let avg_sybil = sybil_coherence.iter().sum::<i32>() / sybil_coherence.len() as i32;
 
         // Honest agents should have significantly higher coherence
-        assert!(avg_honest > avg_sybil,
+        assert!(
+            avg_honest > avg_sybil,
             "Honest agents (avg={}) should have higher coherence than Sybil agents (avg={})",
-            avg_honest, avg_sybil);
+            avg_honest,
+            avg_sybil
+        );
     }
 }

--- a/disentangle-node/src/lib.rs
+++ b/disentangle-node/src/lib.rs
@@ -6,13 +6,13 @@
 //! - SHA2 → SHA3-256 for PoW
 //! - Added coherence validation using structural SimHash
 
-use sha3::{Sha3_256, Digest};
-use disentangle_dag::{Transaction, NodeId};
 use disentangle_crypto::hash::Hash256;
+use disentangle_dag::{NodeId, Transaction};
 use disentangle_simhash::SimHash;
+use sha3::{Digest, Sha3_256};
 
-pub mod identity_state;
 pub mod identity_rpc;
+pub mod identity_state;
 
 pub struct HelloWorldPoW {
     pub target: [u8; 32],
@@ -85,18 +85,18 @@ impl Mempool {
         tx: Transaction,
         nonce: u64,
         now: u64,
-        _parent_simhashes: &[SimHash],  // Reserved: for future SimHash chain validation
+        _parent_simhashes: &[SimHash], // Reserved: for future SimHash chain validation
         expected_history_root: &Hash256,
     ) -> Result<(), MempoolError> {
         let tx_header = self.serialize_header(&tx);
         if !self.pow.validate(&tx_header, nonce) {
             return Err(MempoolError::InvalidPoW);
         }
-        let expected_simhash = SimHash::from_structural(
-            &tx.parents.to_vec(),
-            expected_history_root,
-        );
-        let simhash_valid = tx.simhash.is_coherent(&expected_simhash, disentangle_simhash::COHERENCE_THRESHOLD);
+        let expected_simhash =
+            SimHash::from_structural(&tx.parents.to_vec(), expected_history_root);
+        let simhash_valid = tx
+            .simhash
+            .is_coherent(&expected_simhash, disentangle_simhash::COHERENCE_THRESHOLD);
         let entry = MempoolEntry {
             tx: tx.clone(),
             received_at: now,
@@ -126,15 +126,15 @@ impl Mempool {
             .map(|e| &e.tx)
             .collect()
     }
-    
+
     pub fn remove(&mut self, id: &NodeId) -> Option<MempoolEntry> {
         self.entries.remove(id)
     }
-    
+
     pub fn len(&self) -> usize {
         self.entries.len()
     }
-    
+
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }

--- a/disentangle-node/tests/identity_rpc_tests.rs
+++ b/disentangle-node/tests/identity_rpc_tests.rs
@@ -4,9 +4,9 @@
 //! using Axum's test utilities.
 
 use axum::{
-    Router,
     body::Body,
     http::{Request, StatusCode},
+    Router,
 };
 use disentangle_node::identity_rpc::*;
 use disentangle_node::identity_state::IdentityStateManager;
@@ -21,27 +21,69 @@ fn create_test_router() -> Router {
 
     Router::new()
         // Identity endpoints
-        .route("/identity/register", axum::routing::post(identity_register_handler))
+        .route(
+            "/identity/register",
+            axum::routing::post(identity_register_handler),
+        )
         .route("/identity/:did", axum::routing::get(identity_get_handler))
         .route("/identity", axum::routing::get(identity_list_handler))
-        .route("/identity/:did", axum::routing::delete(identity_deactivate_handler))
+        .route(
+            "/identity/:did",
+            axum::routing::delete(identity_deactivate_handler),
+        )
         // Capability endpoints
-        .route("/capability/create", axum::routing::post(capability_create_handler))
-        .route("/capability/delegate", axum::routing::post(capability_delegate_handler))
-        .route("/capability/invoke", axum::routing::post(capability_invoke_handler))
-        .route("/capability/revoke", axum::routing::post(capability_revoke_handler))
-        .route("/capability/:cap_id_hex", axum::routing::get(capability_get_handler))
-        .route("/capability/by-did/:did", axum::routing::get(capability_list_by_did_handler))
+        .route(
+            "/capability/create",
+            axum::routing::post(capability_create_handler),
+        )
+        .route(
+            "/capability/delegate",
+            axum::routing::post(capability_delegate_handler),
+        )
+        .route(
+            "/capability/invoke",
+            axum::routing::post(capability_invoke_handler),
+        )
+        .route(
+            "/capability/revoke",
+            axum::routing::post(capability_revoke_handler),
+        )
+        .route(
+            "/capability/:cap_id_hex",
+            axum::routing::get(capability_get_handler),
+        )
+        .route(
+            "/capability/by-did/:did",
+            axum::routing::get(capability_list_by_did_handler),
+        )
         // Introduction endpoints
-        .route("/introduction", axum::routing::post(introduction_create_handler))
-        .route("/introduction/chain/:from_did/:to_did", axum::routing::get(introduction_chain_handler))
+        .route(
+            "/introduction",
+            axum::routing::post(introduction_create_handler),
+        )
+        .route(
+            "/introduction/chain/:from_did/:to_did",
+            axum::routing::get(introduction_chain_handler),
+        )
         // Coherence endpoints
-        .route("/coherence/:did", axum::routing::get(coherence_profile_handler))
-        .route("/coherence/curvature/:did_a/:did_b", axum::routing::get(coherence_curvature_handler))
-        .route("/coherence/neighbors/:did", axum::routing::get(coherence_neighbors_handler))
+        .route(
+            "/coherence/:did",
+            axum::routing::get(coherence_profile_handler),
+        )
+        .route(
+            "/coherence/curvature/:did_a/:did_b",
+            axum::routing::get(coherence_curvature_handler),
+        )
+        .route(
+            "/coherence/neighbors/:did",
+            axum::routing::get(coherence_neighbors_handler),
+        )
         // Petname endpoints
         .route("/petname", axum::routing::post(petname_set_handler))
-        .route("/petname/:name", axum::routing::get(petname_resolve_handler))
+        .route(
+            "/petname/:name",
+            axum::routing::get(petname_resolve_handler),
+        )
         .with_state(state)
 }
 
@@ -56,7 +98,9 @@ async fn post_json(router: &Router, path: &str, body: Value) -> (StatusCode, Val
 
     let response = router.clone().oneshot(request).await.unwrap();
     let status = response.status();
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let body_json: Value = serde_json::from_slice(&body_bytes).unwrap_or(json!({}));
 
     (status, body_json)
@@ -72,7 +116,9 @@ async fn get_request(router: &Router, path: &str) -> (StatusCode, Value) {
 
     let response = router.clone().oneshot(request).await.unwrap();
     let status = response.status();
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let body_json: Value = serde_json::from_slice(&body_bytes).unwrap_or(json!({}));
 
     (status, body_json)
@@ -89,7 +135,9 @@ async fn delete_request(router: &Router, path: &str, body: Value) -> (StatusCode
 
     let response = router.clone().oneshot(request).await.unwrap();
     let status = response.status();
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let body_json: Value = serde_json::from_slice(&body_bytes).unwrap_or(json!({}));
 
     (status, body_json)
@@ -153,7 +201,10 @@ async fn test_register_invalid_agent_type() {
     let (status, response) = post_json(&router, "/identity/register", body).await;
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
-    assert!(response["error"].as_str().unwrap().contains("Invalid agent_type"));
+    assert!(response["error"]
+        .as_str()
+        .unwrap()
+        .contains("Invalid agent_type"));
 }
 
 #[tokio::test]
@@ -179,7 +230,10 @@ async fn test_get_nonexistent_identity() {
     let (status, response) = get_request(&router, "/identity/did:disentangle:nonexistent").await;
 
     assert_eq!(status, StatusCode::NOT_FOUND);
-    assert!(response["error"].as_str().unwrap().contains("DID not found"));
+    assert!(response["error"]
+        .as_str()
+        .unwrap()
+        .contains("DID not found"));
 }
 
 #[tokio::test]
@@ -187,7 +241,12 @@ async fn test_list_identities() {
     let router = create_test_router();
 
     // Register two identities
-    post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     post_json(&router, "/identity/register", json!({"agent_type": "agi"})).await;
 
     // List all
@@ -213,7 +272,8 @@ async fn test_deactivate_identity() {
         "proof_hex": "deadbeef"
     });
 
-    let (status, response) = delete_request(&router, &format!("/identity/{}", did), deactivate_body).await;
+    let (status, response) =
+        delete_request(&router, &format!("/identity/{}", did), deactivate_body).await;
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(response["success"], true);
@@ -250,10 +310,14 @@ async fn test_deactivate_invalid_hex() {
         "proof_hex": "not-valid-hex!"
     });
 
-    let (status, response) = delete_request(&router, &format!("/identity/{}", did), deactivate_body).await;
+    let (status, response) =
+        delete_request(&router, &format!("/identity/{}", did), deactivate_body).await;
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
-    assert!(response["error"].as_str().unwrap().contains("Invalid proof hex"));
+    assert!(response["error"]
+        .as_str()
+        .unwrap()
+        .contains("Invalid proof hex"));
 }
 
 // ============================================================================
@@ -320,7 +384,10 @@ async fn test_create_capability_invalid_signing_key() {
     let (status, response) = post_json(&router, "/capability/create", cap_body).await;
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
-    assert!(response["error"].as_str().unwrap().contains("Invalid signing key hex"));
+    assert!(response["error"]
+        .as_str()
+        .unwrap()
+        .contains("Invalid signing key hex"));
 }
 
 #[tokio::test]
@@ -328,11 +395,21 @@ async fn test_delegate_capability() {
     let router = create_test_router();
 
     // Register two identities
-    let (_, issuer_resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, issuer_resp) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let issuer_did = issuer_resp["did"].as_str().unwrap();
     let issuer_sk = issuer_resp["signing_key_hex"].as_str().unwrap();
 
-    let (_, delegatee_resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, delegatee_resp) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let delegatee_did = delegatee_resp["did"].as_str().unwrap();
 
     // Create a delegatable capability
@@ -365,11 +442,21 @@ async fn test_delegate_nonexistent_capability() {
     let router = create_test_router();
 
     // Register an identity
-    let (_, issuer_resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, issuer_resp) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let issuer_did = issuer_resp["did"].as_str().unwrap();
     let issuer_sk = issuer_resp["signing_key_hex"].as_str().unwrap();
 
-    let (_, delegatee_resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, delegatee_resp) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let delegatee_did = delegatee_resp["did"].as_str().unwrap();
 
     // Try to delegate nonexistent capability
@@ -384,18 +471,31 @@ async fn test_delegate_nonexistent_capability() {
     let (status, response) = post_json(&router, "/capability/delegate", delegate_body).await;
 
     assert_eq!(status, StatusCode::FORBIDDEN);
-    assert!(response["error"].as_str().unwrap().contains("Failed to delegate"));
+    assert!(response["error"]
+        .as_str()
+        .unwrap()
+        .contains("Failed to delegate"));
 }
 
 #[tokio::test]
 async fn test_delegate_invalid_cap_id_length() {
     let router = create_test_router();
 
-    let (_, issuer_resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, issuer_resp) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let issuer_did = issuer_resp["did"].as_str().unwrap();
     let issuer_sk = issuer_resp["signing_key_hex"].as_str().unwrap();
 
-    let (_, delegatee_resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, delegatee_resp) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let delegatee_did = delegatee_resp["did"].as_str().unwrap();
 
     // Cap ID that's too short
@@ -409,7 +509,10 @@ async fn test_delegate_invalid_cap_id_length() {
     let (status, response) = post_json(&router, "/capability/delegate", delegate_body).await;
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
-    assert!(response["error"].as_str().unwrap().contains("must be 32 bytes"));
+    assert!(response["error"]
+        .as_str()
+        .unwrap()
+        .contains("must be 32 bytes"));
 }
 
 #[tokio::test]
@@ -417,7 +520,12 @@ async fn test_invoke_capability_as_issuer() {
     let router = create_test_router();
 
     // Register identity and create capability
-    let (_, issuer_resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, issuer_resp) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let issuer_did = issuer_resp["did"].as_str().unwrap();
     let issuer_sk = issuer_resp["signing_key_hex"].as_str().unwrap();
 
@@ -441,7 +549,10 @@ async fn test_invoke_capability_as_issuer() {
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(response["success"], true);
-    assert!(response["message"].as_str().unwrap().contains("successfully"));
+    assert!(response["message"]
+        .as_str()
+        .unwrap()
+        .contains("successfully"));
 }
 
 #[tokio::test]
@@ -449,11 +560,21 @@ async fn test_invoke_capability_unauthorized() {
     let router = create_test_router();
 
     // Register two identities
-    let (_, issuer_resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, issuer_resp) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let issuer_did = issuer_resp["did"].as_str().unwrap();
     let issuer_sk = issuer_resp["signing_key_hex"].as_str().unwrap();
 
-    let (_, other_resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, other_resp) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let other_did = other_resp["did"].as_str().unwrap();
 
     // Create capability
@@ -476,8 +597,16 @@ async fn test_invoke_capability_unauthorized() {
     let (status, response) = post_json(&router, "/capability/invoke", invoke_body).await;
 
     assert_eq!(status, StatusCode::FORBIDDEN);
-    assert!(response["error"].as_str().unwrap().contains("not permitted") ||
-            response["error"].as_str().unwrap().contains("delegation chain"));
+    assert!(
+        response["error"]
+            .as_str()
+            .unwrap()
+            .contains("not permitted")
+            || response["error"]
+                .as_str()
+                .unwrap()
+                .contains("delegation chain")
+    );
 }
 
 #[tokio::test]
@@ -485,7 +614,12 @@ async fn test_revoke_capability() {
     let router = create_test_router();
 
     // Register identity and create capability
-    let (_, issuer_resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, issuer_resp) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let issuer_did = issuer_resp["did"].as_str().unwrap();
     let issuer_sk = issuer_resp["signing_key_hex"].as_str().unwrap();
 
@@ -516,16 +650,25 @@ async fn test_revoke_capability() {
         "capability_id_hex": cap_id_hex,
         "invoker_did": issuer_did
     });
-    let (invoke_status, invoke_response) = post_json(&router, "/capability/invoke", invoke_body).await;
+    let (invoke_status, invoke_response) =
+        post_json(&router, "/capability/invoke", invoke_body).await;
     assert_eq!(invoke_status, StatusCode::FORBIDDEN);
-    assert!(invoke_response["error"].as_str().unwrap().contains("revoked"));
+    assert!(invoke_response["error"]
+        .as_str()
+        .unwrap()
+        .contains("revoked"));
 }
 
 #[tokio::test]
 async fn test_revoke_invalid_scope() {
     let router = create_test_router();
 
-    let (_, issuer_resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, issuer_resp) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let issuer_did = issuer_resp["did"].as_str().unwrap();
     let issuer_sk = issuer_resp["signing_key_hex"].as_str().unwrap();
 
@@ -549,7 +692,10 @@ async fn test_revoke_invalid_scope() {
     let (status, response) = post_json(&router, "/capability/revoke", revoke_body).await;
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
-    assert!(response["error"].as_str().unwrap().contains("Invalid scope"));
+    assert!(response["error"]
+        .as_str()
+        .unwrap()
+        .contains("Invalid scope"));
 }
 
 #[tokio::test]
@@ -557,7 +703,12 @@ async fn test_get_capability() {
     let router = create_test_router();
 
     // Create capability
-    let (_, issuer_resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, issuer_resp) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let issuer_did = issuer_resp["did"].as_str().unwrap();
     let issuer_sk = issuer_resp["signing_key_hex"].as_str().unwrap();
 
@@ -596,7 +747,10 @@ async fn test_get_capability_invalid_hex() {
     let (status, response) = get_request(&router, "/capability/not-valid-hex").await;
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
-    assert!(response["error"].as_str().unwrap().contains("Invalid capability ID hex"));
+    assert!(response["error"]
+        .as_str()
+        .unwrap()
+        .contains("Invalid capability ID hex"));
 }
 
 #[tokio::test]
@@ -604,12 +758,18 @@ async fn test_list_capabilities_by_did() {
     let router = create_test_router();
 
     // Register identity
-    let (_, issuer_resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, issuer_resp) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let issuer_did = issuer_resp["did"].as_str().unwrap();
     let issuer_sk = issuer_resp["signing_key_hex"].as_str().unwrap();
 
     // Initially no capabilities
-    let (status, response) = get_request(&router, &format!("/capability/by-did/{}", issuer_did)).await;
+    let (status, response) =
+        get_request(&router, &format!("/capability/by-did/{}", issuer_did)).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(response["capabilities"].as_array().unwrap().len(), 0);
 
@@ -624,7 +784,8 @@ async fn test_list_capabilities_by_did() {
     post_json(&router, "/capability/create", cap_body).await;
 
     // Now should have 1 capability
-    let (status, response) = get_request(&router, &format!("/capability/by-did/{}", issuer_did)).await;
+    let (status, response) =
+        get_request(&router, &format!("/capability/by-did/{}", issuer_did)).await;
     assert_eq!(status, StatusCode::OK);
     assert!(response["capabilities"].is_array());
     let caps = response["capabilities"].as_array().unwrap();
@@ -643,11 +804,21 @@ async fn test_create_introduction() {
     let router = create_test_router();
 
     // Register two identities
-    let (_, introducer_resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, introducer_resp) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let introducer_did = introducer_resp["did"].as_str().unwrap();
     let introducer_sk = introducer_resp["signing_key_hex"].as_str().unwrap();
 
-    let (_, introduced_resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, introduced_resp) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let introduced_did = introduced_resp["did"].as_str().unwrap();
 
     // Create introduction
@@ -668,7 +839,12 @@ async fn test_create_introduction() {
 async fn test_introduction_nonexistent_did() {
     let router = create_test_router();
 
-    let (_, introducer_resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, introducer_resp) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let introducer_did = introducer_resp["did"].as_str().unwrap();
     let introducer_sk = introducer_resp["signing_key_hex"].as_str().unwrap();
 
@@ -682,7 +858,10 @@ async fn test_introduction_nonexistent_did() {
     let (status, response) = post_json(&router, "/introduction", intro_body).await;
 
     assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
-    assert!(response["error"].as_str().unwrap().contains("DID not found"));
+    assert!(response["error"]
+        .as_str()
+        .unwrap()
+        .contains("DID not found"));
 }
 
 // ============================================================================
@@ -694,7 +873,12 @@ async fn test_get_coherence_profile() {
     let router = create_test_router();
 
     // Register identity
-    let (_, resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did = resp["did"].as_str().unwrap();
 
     // Get coherence profile
@@ -721,11 +905,21 @@ async fn test_get_curvature_between_dids() {
     let router = create_test_router();
 
     // Register two identities and introduce them
-    let (_, resp_a) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp_a) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did_a = resp_a["did"].as_str().unwrap();
     let sk_a = resp_a["signing_key_hex"].as_str().unwrap();
 
-    let (_, resp_b) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp_b) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did_b = resp_b["did"].as_str().unwrap();
 
     // Introduce them
@@ -738,7 +932,11 @@ async fn test_get_curvature_between_dids() {
     post_json(&router, "/introduction", intro_body).await;
 
     // Get curvature
-    let (status, response) = get_request(&router, &format!("/coherence/curvature/{}/{}", did_a, did_b)).await;
+    let (status, response) = get_request(
+        &router,
+        &format!("/coherence/curvature/{}/{}", did_a, did_b),
+    )
+    .await;
 
     assert_eq!(status, StatusCode::OK);
     assert!(response["curvature"].is_number());
@@ -749,11 +947,21 @@ async fn test_get_neighbors() {
     let router = create_test_router();
 
     // Register two identities and introduce them
-    let (_, resp_a) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp_a) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did_a = resp_a["did"].as_str().unwrap();
     let sk_a = resp_a["signing_key_hex"].as_str().unwrap();
 
-    let (_, resp_b) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp_b) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did_b = resp_b["did"].as_str().unwrap();
 
     // Introduce them
@@ -784,7 +992,12 @@ async fn test_set_petname() {
     let router = create_test_router();
 
     // Register identity
-    let (_, resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did = resp["did"].as_str().unwrap();
 
     // Set petname
@@ -804,7 +1017,12 @@ async fn test_resolve_petname() {
     let router = create_test_router();
 
     // Register identity
-    let (_, resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did = resp["did"].as_str().unwrap();
 
     // Set petname
@@ -840,15 +1058,30 @@ async fn test_full_capability_delegation_chain() {
     let router = create_test_router();
 
     // Register three identities: A -> B -> C
-    let (_, resp_a) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp_a) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did_a = resp_a["did"].as_str().unwrap();
     let sk_a = resp_a["signing_key_hex"].as_str().unwrap();
 
-    let (_, resp_b) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp_b) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did_b = resp_b["did"].as_str().unwrap();
     let sk_b = resp_b["signing_key_hex"].as_str().unwrap();
 
-    let (_, resp_c) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp_c) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did_c = resp_c["did"].as_str().unwrap();
 
     // A creates capability
@@ -897,43 +1130,78 @@ async fn test_coherence_with_introduction_graph() {
     let router = create_test_router();
 
     // Create a small social graph: A introduces B and C, B introduces D
-    let (_, resp_a) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp_a) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did_a = resp_a["did"].as_str().unwrap();
     let sk_a = resp_a["signing_key_hex"].as_str().unwrap();
 
-    let (_, resp_b) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp_b) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did_b = resp_b["did"].as_str().unwrap();
     let sk_b = resp_b["signing_key_hex"].as_str().unwrap();
 
-    let (_, resp_c) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp_c) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did_c = resp_c["did"].as_str().unwrap();
 
-    let (_, resp_d) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp_d) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did_d = resp_d["did"].as_str().unwrap();
 
     // A introduces B
-    post_json(&router, "/introduction", json!({
-        "introducer_did": did_a,
-        "introducer_sk_hex": sk_a,
-        "introduced_did": did_b,
-        "edge_name": "Colleague"
-    })).await;
+    post_json(
+        &router,
+        "/introduction",
+        json!({
+            "introducer_did": did_a,
+            "introducer_sk_hex": sk_a,
+            "introduced_did": did_b,
+            "edge_name": "Colleague"
+        }),
+    )
+    .await;
 
     // A introduces C
-    post_json(&router, "/introduction", json!({
-        "introducer_did": did_a,
-        "introducer_sk_hex": sk_a,
-        "introduced_did": did_c,
-        "edge_name": "Friend"
-    })).await;
+    post_json(
+        &router,
+        "/introduction",
+        json!({
+            "introducer_did": did_a,
+            "introducer_sk_hex": sk_a,
+            "introduced_did": did_c,
+            "edge_name": "Friend"
+        }),
+    )
+    .await;
 
     // B introduces D
-    post_json(&router, "/introduction", json!({
-        "introducer_did": did_b,
-        "introducer_sk_hex": sk_b,
-        "introduced_did": did_d,
-        "edge_name": "Friend"
-    })).await;
+    post_json(
+        &router,
+        "/introduction",
+        json!({
+            "introducer_did": did_b,
+            "introducer_sk_hex": sk_b,
+            "introduced_did": did_d,
+            "edge_name": "Friend"
+        }),
+    )
+    .await;
 
     // Verify A has 2 neighbors
     let (status, response) = get_request(&router, &format!("/coherence/neighbors/{}", did_a)).await;
@@ -962,15 +1230,30 @@ async fn test_capability_revocation_prevents_downstream_invocation() {
     let router = create_test_router();
 
     // Register three identities: A, B, C
-    let (_, resp_a) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp_a) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did_a = resp_a["did"].as_str().unwrap().to_string();
     let sk_a = resp_a["signing_key_hex"].as_str().unwrap().to_string();
 
-    let (_, resp_b) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp_b) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did_b = resp_b["did"].as_str().unwrap().to_string();
     let sk_b = resp_b["signing_key_hex"].as_str().unwrap().to_string();
 
-    let (_, resp_c) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp_c) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did_c = resp_c["did"].as_str().unwrap().to_string();
 
     // A creates a delegatable capability
@@ -986,47 +1269,79 @@ async fn test_capability_revocation_prevents_downstream_invocation() {
     let cap_id_hex = cap_resp["capability_id_hex"].as_str().unwrap().to_string();
 
     // A delegates to B
-    let (status, _) = post_json(&router, "/capability/delegate", json!({
-        "capability_id_hex": cap_id_hex,
-        "delegator_did": did_a,
-        "delegator_sk_hex": sk_a,
-        "delegatee_did": did_b
-    })).await;
+    let (status, _) = post_json(
+        &router,
+        "/capability/delegate",
+        json!({
+            "capability_id_hex": cap_id_hex,
+            "delegator_did": did_a,
+            "delegator_sk_hex": sk_a,
+            "delegatee_did": did_b
+        }),
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
 
     // B delegates to C
-    let (status, _) = post_json(&router, "/capability/delegate", json!({
-        "capability_id_hex": cap_id_hex,
-        "delegator_did": did_b,
-        "delegator_sk_hex": sk_b,
-        "delegatee_did": did_c
-    })).await;
+    let (status, _) = post_json(
+        &router,
+        "/capability/delegate",
+        json!({
+            "capability_id_hex": cap_id_hex,
+            "delegator_did": did_b,
+            "delegator_sk_hex": sk_b,
+            "delegatee_did": did_c
+        }),
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
 
     // Verify C can invoke before revocation
-    let (status, response) = post_json(&router, "/capability/invoke", json!({
-        "capability_id_hex": cap_id_hex,
-        "invoker_did": did_c
-    })).await;
-    assert_eq!(status, StatusCode::OK, "C should be able to invoke before revocation");
+    let (status, response) = post_json(
+        &router,
+        "/capability/invoke",
+        json!({
+            "capability_id_hex": cap_id_hex,
+            "invoker_did": did_c
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "C should be able to invoke before revocation"
+    );
     assert_eq!(response["success"], true);
 
     // A revokes the capability
-    let (status, response) = post_json(&router, "/capability/revoke", json!({
-        "capability_id_hex": cap_id_hex,
-        "revoker_did": did_a,
-        "scope": "single"
-    })).await;
+    let (status, response) = post_json(
+        &router,
+        "/capability/revoke",
+        json!({
+            "capability_id_hex": cap_id_hex,
+            "revoker_did": did_a,
+            "scope": "single"
+        }),
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(response["success"], true);
 
     // C should no longer be able to invoke
-    let (status, response) = post_json(&router, "/capability/invoke", json!({
-        "capability_id_hex": cap_id_hex,
-        "invoker_did": did_c
-    })).await;
-    assert_eq!(status, StatusCode::FORBIDDEN,
-        "C should NOT be able to invoke after A revoked the capability");
+    let (status, response) = post_json(
+        &router,
+        "/capability/invoke",
+        json!({
+            "capability_id_hex": cap_id_hex,
+            "invoker_did": did_c
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "C should NOT be able to invoke after A revoked the capability"
+    );
     assert!(
         response["error"].as_str().unwrap().contains("revoked"),
         "Error should mention revocation, got: {}",
@@ -1034,24 +1349,40 @@ async fn test_capability_revocation_prevents_downstream_invocation() {
     );
 
     // B should also be blocked
-    let (status, response) = post_json(&router, "/capability/invoke", json!({
-        "capability_id_hex": cap_id_hex,
-        "invoker_did": did_b
-    })).await;
-    assert_eq!(status, StatusCode::FORBIDDEN,
-        "B should NOT be able to invoke after A revoked the capability");
+    let (status, response) = post_json(
+        &router,
+        "/capability/invoke",
+        json!({
+            "capability_id_hex": cap_id_hex,
+            "invoker_did": did_b
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "B should NOT be able to invoke after A revoked the capability"
+    );
     assert!(
         response["error"].as_str().unwrap().contains("revoked"),
         "Error should mention revocation for B as well"
     );
 
     // Even the original issuer A is blocked (revocation is absolute)
-    let (status, response) = post_json(&router, "/capability/invoke", json!({
-        "capability_id_hex": cap_id_hex,
-        "invoker_did": did_a
-    })).await;
-    assert_eq!(status, StatusCode::FORBIDDEN,
-        "A should NOT be able to invoke their own revoked capability");
+    let (status, response) = post_json(
+        &router,
+        "/capability/invoke",
+        json!({
+            "capability_id_hex": cap_id_hex,
+            "invoker_did": did_a
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "A should NOT be able to invoke their own revoked capability"
+    );
     assert!(
         response["error"].as_str().unwrap().contains("revoked"),
         "Error should mention revocation for A as well"
@@ -1073,12 +1404,22 @@ async fn test_combined_delegation_and_coherence_constraint() {
     let router = create_test_router();
 
     // Register identities: issuer + hub agent + connected agents + isolated agent
-    let (_, resp_issuer) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp_issuer) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did_issuer = resp_issuer["did"].as_str().unwrap().to_string();
     let sk_issuer = resp_issuer["signing_key_hex"].as_str().unwrap().to_string();
 
     // "Hub" agent -- will have high coherence through many positive-curvature edges
-    let (_, resp_hub) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp_hub) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did_hub = resp_hub["did"].as_str().unwrap().to_string();
     let sk_hub = resp_hub["signing_key_hex"].as_str().unwrap().to_string();
 
@@ -1086,46 +1427,71 @@ async fn test_combined_delegation_and_coherence_constraint() {
     let mut mesh_dids = vec![];
     let mut mesh_sks = vec![];
     for _ in 0..5 {
-        let (_, resp) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+        let (_, resp) = post_json(
+            &router,
+            "/identity/register",
+            json!({"agent_type": "human"}),
+        )
+        .await;
         mesh_dids.push(resp["did"].as_str().unwrap().to_string());
         mesh_sks.push(resp["signing_key_hex"].as_str().unwrap().to_string());
     }
 
     // Isolated agent -- zero coherence (no introductions at all)
-    let (_, resp_isolated) = post_json(&router, "/identity/register", json!({"agent_type": "human"})).await;
+    let (_, resp_isolated) = post_json(
+        &router,
+        "/identity/register",
+        json!({"agent_type": "human"}),
+    )
+    .await;
     let did_isolated = resp_isolated["did"].as_str().unwrap().to_string();
 
     // Build introduction graph: hub introduces all mesh agents
-    for i in 0..mesh_dids.len() {
-        let (status, _) = post_json(&router, "/introduction", json!({
-            "introducer_did": did_hub,
-            "introducer_sk_hex": sk_hub,
-            "introduced_did": mesh_dids[i],
-            "edge_name": "Colleague"
-        })).await;
+    for mesh_did in &mesh_dids {
+        let (status, _) = post_json(
+            &router,
+            "/introduction",
+            json!({
+                "introducer_did": did_hub,
+                "introducer_sk_hex": sk_hub,
+                "introduced_did": mesh_did,
+                "edge_name": "Colleague"
+            }),
+        )
+        .await;
         assert_eq!(status, StatusCode::OK);
     }
 
     // Mesh agents introduce each other to create triangles (positive curvature)
     for i in 0..mesh_dids.len() {
         for j in (i + 1)..mesh_dids.len() {
-            let (status, _) = post_json(&router, "/introduction", json!({
-                "introducer_did": mesh_dids[i],
-                "introducer_sk_hex": mesh_sks[i],
-                "introduced_did": mesh_dids[j],
-                "edge_name": "Peer"
-            })).await;
+            let (status, _) = post_json(
+                &router,
+                "/introduction",
+                json!({
+                    "introducer_did": mesh_dids[i],
+                    "introducer_sk_hex": mesh_sks[i],
+                    "introduced_did": mesh_dids[j],
+                    "edge_name": "Peer"
+                }),
+            )
+            .await;
             assert_eq!(status, StatusCode::OK);
         }
     }
 
     // Also connect issuer to the hub so issuer has introductions
-    let (status, _) = post_json(&router, "/introduction", json!({
-        "introducer_did": did_issuer,
-        "introducer_sk_hex": sk_issuer,
-        "introduced_did": did_hub,
-        "edge_name": "Friend"
-    })).await;
+    let (status, _) = post_json(
+        &router,
+        "/introduction",
+        json!({
+            "introducer_did": did_issuer,
+            "introducer_sk_hex": sk_issuer,
+            "introduced_did": did_hub,
+            "edge_name": "Friend"
+        }),
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
 
     // Verify hub has high coherence (topological_mass > 0)
@@ -1133,14 +1499,23 @@ async fn test_combined_delegation_and_coherence_constraint() {
     assert_eq!(status, StatusCode::OK);
     let hub_mass = hub_profile["profile"]["topological_mass"].as_i64().unwrap();
     println!("    Hub topological mass: {}", hub_mass);
-    assert!(hub_mass > 0, "Hub should have positive topological mass from mesh connections");
+    assert!(
+        hub_mass > 0,
+        "Hub should have positive topological mass from mesh connections"
+    );
 
     // Verify isolated agent has zero coherence
-    let (status, isolated_profile) = get_request(&router, &format!("/coherence/{}", did_isolated)).await;
+    let (status, isolated_profile) =
+        get_request(&router, &format!("/coherence/{}", did_isolated)).await;
     assert_eq!(status, StatusCode::OK);
-    let isolated_mass = isolated_profile["profile"]["topological_mass"].as_i64().unwrap();
+    let isolated_mass = isolated_profile["profile"]["topological_mass"]
+        .as_i64()
+        .unwrap();
     println!("    Isolated agent topological mass: {}", isolated_mass);
-    assert_eq!(isolated_mass, 0, "Isolated agent should have zero topological mass");
+    assert_eq!(
+        isolated_mass, 0,
+        "Isolated agent should have zero topological mass"
+    );
 
     // Create a capability with CoherenceMinimum constraint.
     // The min_mass is in units of topological_mass / SCALE, so we set it
@@ -1163,44 +1538,70 @@ async fn test_combined_delegation_and_coherence_constraint() {
     let cap_id_hex = cap_resp["capability_id_hex"].as_str().unwrap().to_string();
 
     // Delegate to both hub and isolated
-    let (status, _) = post_json(&router, "/capability/delegate", json!({
-        "capability_id_hex": cap_id_hex,
-        "delegator_did": did_issuer,
-        "delegator_sk_hex": sk_issuer,
-        "delegatee_did": did_hub
-    })).await;
+    let (status, _) = post_json(
+        &router,
+        "/capability/delegate",
+        json!({
+            "capability_id_hex": cap_id_hex,
+            "delegator_did": did_issuer,
+            "delegator_sk_hex": sk_issuer,
+            "delegatee_did": did_hub
+        }),
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
 
-    let (status, _) = post_json(&router, "/capability/delegate", json!({
-        "capability_id_hex": cap_id_hex,
-        "delegator_did": did_issuer,
-        "delegator_sk_hex": sk_issuer,
-        "delegatee_did": did_isolated
-    })).await;
+    let (status, _) = post_json(
+        &router,
+        "/capability/delegate",
+        json!({
+            "capability_id_hex": cap_id_hex,
+            "delegator_did": did_issuer,
+            "delegator_sk_hex": sk_issuer,
+            "delegatee_did": did_isolated
+        }),
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
 
     // Hub should be able to invoke (high coherence >= min_mass)
-    let (status, response) = post_json(&router, "/capability/invoke", json!({
-        "capability_id_hex": cap_id_hex,
-        "invoker_did": did_hub
-    })).await;
-    assert_eq!(status, StatusCode::OK,
+    let (status, response) = post_json(
+        &router,
+        "/capability/invoke",
+        json!({
+            "capability_id_hex": cap_id_hex,
+            "invoker_did": did_hub
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
         "Hub agent with high coherence should be able to invoke. Response: {:?}",
-        response);
+        response
+    );
     assert_eq!(response["success"], true);
 
     // Isolated agent should be blocked (zero coherence < min_mass)
-    let (status, response) = post_json(&router, "/capability/invoke", json!({
-        "capability_id_hex": cap_id_hex,
-        "invoker_did": did_isolated
-    })).await;
+    let (status, response) = post_json(
+        &router,
+        "/capability/invoke",
+        json!({
+            "capability_id_hex": cap_id_hex,
+            "invoker_did": did_isolated
+        }),
+    )
+    .await;
     assert_eq!(status, StatusCode::FORBIDDEN,
         "Isolated agent with zero coherence should be blocked by CoherenceMinimum constraint. Response: {:?}",
         response);
     assert!(
-        response["error"].as_str().unwrap().contains("constraint") ||
-        response["error"].as_str().unwrap().contains("not met") ||
-        response["error"].as_str().unwrap().contains("not permitted"),
+        response["error"].as_str().unwrap().contains("constraint")
+            || response["error"].as_str().unwrap().contains("not met")
+            || response["error"]
+                .as_str()
+                .unwrap()
+                .contains("not permitted"),
         "Error should indicate constraint failure, got: {}",
         response["error"]
     );

--- a/disentangle-node/tests/test_identity_completeness.rs
+++ b/disentangle-node/tests/test_identity_completeness.rs
@@ -1,22 +1,23 @@
 #[cfg(test)]
 mod tests {
-    use disentangle_node::identity_state::IdentityStateManager;
     use disentangle_identity::{AgentType, ProposalType, VoteChoice};
+    use disentangle_node::identity_state::IdentityStateManager;
     use std::path::Path;
-    
+
     #[test]
     fn test_introduction_chain_pathfinding() {
         let mut mgr = IdentityStateManager::new();
-        
+
         // Create three DIDs
         let (did_a, _, sk_a) = mgr.register_did(AgentType::Human).unwrap();
         let (did_b, _, sk_b) = mgr.register_did(AgentType::Human).unwrap();
         let (did_c, _, _sk_c) = mgr.register_did(AgentType::Human).unwrap();
-        
+
         // Create introduction chain: A -> B -> C
         mgr.introduce(&did_a.0, &sk_a, &did_b.0, "Friend").unwrap();
-        mgr.introduce(&did_b.0, &sk_b, &did_c.0, "FriendOfFriend").unwrap();
-        
+        mgr.introduce(&did_b.0, &sk_b, &did_c.0, "FriendOfFriend")
+            .unwrap();
+
         // Test pathfinding
         let chain = mgr.get_introduction_chain(&did_a.0, &did_c.0);
         assert!(chain.is_some());
@@ -25,95 +26,95 @@ mod tests {
         assert_eq!(chain[0], did_a.0);
         assert_eq!(chain[1], did_b.0);
         assert_eq!(chain[2], did_c.0);
-        
+
         // Test direct connection
         let direct = mgr.get_introduction_chain(&did_a.0, &did_b.0);
         assert!(direct.is_some());
         assert_eq!(direct.unwrap().len(), 2); // [A, B]
     }
-    
+
     #[test]
     fn test_governance_proposal_and_voting() {
         let mut mgr = IdentityStateManager::new();
-        
+
         // Register DIDs
         let (proposer_did, _, proposer_sk) = mgr.register_did(AgentType::Human).unwrap();
         let (voter_did, _, voter_sk) = mgr.register_did(AgentType::Human).unwrap();
-        
+
         // Create proposal
         let proposal_type = ProposalType::ProtocolParameter {
             parameter: "alpha_max".to_string(),
             new_value: vec![0, 0, 0, 5],
         };
-        
-        let proposal = mgr.create_proposal(
-            &proposer_did.0,
-            &proposer_sk,
-            proposal_type,
-            "Increase alpha_max to 5",
-            100, // duration_blocks
-        ).unwrap();
-        
+
+        let proposal = mgr
+            .create_proposal(
+                &proposer_did.0,
+                &proposer_sk,
+                proposal_type,
+                "Increase alpha_max to 5",
+                100, // duration_blocks
+            )
+            .unwrap();
+
         // Cast vote
-        let vote = mgr.cast_vote(
-            &proposal.id,
-            &voter_did.0,
-            &voter_sk,
-            VoteChoice::For,
-        ).unwrap();
-        
+        let vote = mgr
+            .cast_vote(&proposal.id, &voter_did.0, &voter_sk, VoteChoice::For)
+            .unwrap();
+
         assert_eq!(vote.vote, VoteChoice::For);
         assert_eq!(vote.proposal_id, proposal.id);
-        
+
         // List proposals
         let proposals = mgr.list_proposals();
         assert_eq!(proposals.len(), 1);
-        
+
         // Get proposal
         let retrieved = mgr.get_proposal(&proposal.id);
         assert!(retrieved.is_some());
-        
+
         // Evaluate (should be pending since we haven't advanced blocks)
         let result = mgr.evaluate_proposal(&proposal.id);
         assert!(result.is_some());
     }
-    
+
     #[test]
     fn test_state_persistence() {
         let temp_path = Path::new("/tmp/test_disentangle_state.json");
-        
+
         // Clean up if exists
         let _ = std::fs::remove_file(temp_path);
-        
+
         // Create state and save
         {
             let mut mgr = IdentityStateManager::new();
-            
+
             let (did_a, _, sk_a) = mgr.register_did(AgentType::Human).unwrap();
             let (did_b, _, _sk_b) = mgr.register_did(AgentType::Human).unwrap();
-            
+
             mgr.introduce(&did_a.0, &sk_a, &did_b.0, "Friend").unwrap();
             mgr.set_petname("Alice", &did_a.0).unwrap();
-            
+
             mgr.save_to_file(temp_path).unwrap();
         }
-        
+
         // Load state and verify
         {
             let loaded = IdentityStateManager::load_from_file(temp_path).unwrap();
-            
+
             let dids = loaded.list_dids();
             assert_eq!(dids.len(), 2);
-            
+
             // Petnames are not persisted (local-first)
             // but DIDs and introductions should be
-            
+
             // Verify introduction chain exists
-            let chain = loaded.get_introduction_chain(&dids[0], &dids[1])
+            let chain = loaded
+                .get_introduction_chain(&dids[0], &dids[1])
                 .or_else(|| loaded.get_introduction_chain(&dids[1], &dids[0]));
             assert!(chain.is_some());
         }
-        
+
         // Clean up
         let _ = std::fs::remove_file(temp_path);
     }

--- a/disentangle-p2p/src/behaviour.rs
+++ b/disentangle-p2p/src/behaviour.rs
@@ -1,5 +1,7 @@
 //! Network behavior combining Gossipsub + RequestResponse.
 
+use crate::pq_transport::PqRekeyMessage;
+use crate::wire::{GOSSIP_TOPIC, MAX_MESSAGE_SIZE, PQ_REKEY_PROTOCOL, PROTOCOL_VERSION};
 use libp2p::{
     gossipsub::{self, IdentTopic, MessageAuthenticity, ValidationMode},
     identify,
@@ -10,13 +12,12 @@ use libp2p::{
 };
 use std::collections::HashSet;
 use std::time::Duration;
-use crate::wire::{GOSSIP_TOPIC, PROTOCOL_VERSION, PQ_REKEY_PROTOCOL, MAX_MESSAGE_SIZE};
-use crate::pq_transport::PqRekeyMessage;
 
 #[derive(NetworkBehaviour)]
 pub struct DisentangleBehaviour {
     pub gossipsub: gossipsub::Behaviour,
-    pub request_response: request_response::cbor::Behaviour<DisentangleRequest, DisentangleResponse>,
+    pub request_response:
+        request_response::cbor::Behaviour<DisentangleRequest, DisentangleResponse>,
     pub pq_rekey: request_response::cbor::Behaviour<PqRekeyMessage, PqRekeyMessage>,
     pub kademlia: kad::Behaviour<MemoryStore>,
     pub identify: identify::Behaviour,
@@ -79,23 +80,19 @@ impl DisentangleBehaviour {
             .max_transmit_size(MAX_MESSAGE_SIZE)
             .build()
             .expect("Valid gossipsub config");
-        let mut behaviour = gossipsub::Behaviour::new(
-            MessageAuthenticity::Signed(local_key.clone()),
-            config,
-        ).expect("Valid gossipsub behaviour");
+        let mut behaviour =
+            gossipsub::Behaviour::new(MessageAuthenticity::Signed(local_key.clone()), config)
+                .expect("Valid gossipsub behaviour");
         let topic = IdentTopic::new(GOSSIP_TOPIC);
         behaviour.subscribe(&topic).expect("Subscribe to topic");
         behaviour
     }
 
-
-    fn build_request_response() -> request_response::cbor::Behaviour<DisentangleRequest, DisentangleResponse> {
-        let protocols = [(
-            StreamProtocol::new(PROTOCOL_VERSION),
-            ProtocolSupport::Full,
-        )];
-        let config = request_response::Config::default()
-            .with_request_timeout(Duration::from_secs(30));
+    fn build_request_response(
+    ) -> request_response::cbor::Behaviour<DisentangleRequest, DisentangleResponse> {
+        let protocols = [(StreamProtocol::new(PROTOCOL_VERSION), ProtocolSupport::Full)];
+        let config =
+            request_response::Config::default().with_request_timeout(Duration::from_secs(30));
         request_response::cbor::Behaviour::new(protocols, config)
     }
 
@@ -104,8 +101,8 @@ impl DisentangleBehaviour {
             StreamProtocol::new(PQ_REKEY_PROTOCOL),
             ProtocolSupport::Full,
         )];
-        let config = request_response::Config::default()
-            .with_request_timeout(Duration::from_secs(10));
+        let config =
+            request_response::Config::default().with_request_timeout(Duration::from_secs(10));
         request_response::cbor::Behaviour::new(protocols, config)
     }
 
@@ -116,10 +113,7 @@ impl DisentangleBehaviour {
     }
 
     fn build_identify(local_key: &libp2p::identity::Keypair) -> identify::Behaviour {
-        let config = identify::Config::new(
-            PROTOCOL_VERSION.to_string(),
-            local_key.public(),
-        );
+        let config = identify::Config::new(PROTOCOL_VERSION.to_string(), local_key.public());
         identify::Behaviour::new(config)
     }
 

--- a/disentangle-p2p/src/bin/node.rs
+++ b/disentangle-p2p/src/bin/node.rs
@@ -2,28 +2,27 @@
 //!
 //! Full node with P2P networking and HTTP RPC interface.
 
-use disentangle_p2p::{
-    build_swarm, generate_keypair, parse_peer_addr,
-    WireMessage, WireTransaction, SyncState, SyncResult,
-    behaviour::{DisentangleRequest, DisentangleResponse},
-    GOSSIP_TOPIC,
-};
-use disentangle_dag::{Transaction, NodeId, SCALE};
-use disentangle_consensus::{resolve_conflict, ConflictWinner, compute_curvature};
-use disentangle_simhash::SimHash;
-use disentangle_node::{HelloWorldPoW, identity_state::IdentityStateManager, identity_rpc};
+use disentangle_consensus::{compute_curvature, resolve_conflict, ConflictWinner};
 use disentangle_crypto::{
-    signature::{generate_keypair as generate_dilithium_keypair, sign as dilithium_sign},
     hash::{sha3_256, Hash256},
-    types::{Nullifier, Epoch},
+    signature::{generate_keypair as generate_dilithium_keypair, sign as dilithium_sign},
+    types::{Epoch, Nullifier},
 };
+use disentangle_dag::{NodeId, Transaction, SCALE};
+use disentangle_node::{identity_rpc, identity_state::IdentityStateManager, HelloWorldPoW};
+use disentangle_p2p::{
+    behaviour::{DisentangleRequest, DisentangleResponse},
+    build_swarm, generate_keypair, parse_peer_addr, SyncResult, SyncState, WireMessage,
+    WireTransaction, GOSSIP_TOPIC,
+};
+use disentangle_simhash::SimHash;
 
 use libp2p::{
+    futures::StreamExt,
     gossipsub::{self, IdentTopic},
     identify,
     request_response::{self, OutboundRequestId},
     swarm::SwarmEvent,
-    futures::StreamExt,
     Multiaddr, PeerId, Swarm,
 };
 use std::collections::HashSet;
@@ -32,7 +31,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{mpsc, Mutex};
 use tokio::time::{interval, Interval};
-use tracing::{info, warn, debug};
+use tracing::{debug, info, warn};
 use tracing_subscriber::EnvFilter;
 
 use axum::{
@@ -40,12 +39,11 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use tower_http::cors::{CorsLayer, Any};
 use serde::{Deserialize, Serialize};
+use tower_http::cors::{Any, CorsLayer};
 
 const POW_DIFFICULTY: u8 = 16;
 const MINE_INTERVAL_SECS: u64 = 10;
-
 
 #[derive(Clone)]
 struct SharedState {
@@ -70,7 +68,10 @@ struct ConflictRecord {
 
 enum NodeCommand {
     BroadcastTx(WireTransaction),
-    TargetedBroadcast { tx: WireTransaction, target_peer: Option<usize> },
+    TargetedBroadcast {
+        tx: WireTransaction,
+        target_peer: Option<usize>,
+    },
 }
 
 #[derive(Serialize)]
@@ -131,7 +132,6 @@ struct GraphEdge {
     curvature: f64,
 }
 
-
 async fn status_handler(State(state): State<SharedState>) -> Json<StatusResponse> {
     let sync = state.sync.lock().await;
     let tips: Vec<String> = sync.tips().iter().map(|t| hex::encode(&t[..8])).collect();
@@ -154,7 +154,8 @@ async fn graph_handler(State(state): State<SharedState>) -> Json<GraphResponse> 
     let dag = sync.dag();
     let tips_set: HashSet<NodeId> = sync.tips().into_iter().collect();
     let conflicts = state.conflicts_resolved.lock().await;
-    let conflict_ids: HashSet<String> = conflicts.iter()
+    let conflict_ids: HashSet<String> = conflicts
+        .iter()
         .flat_map(|c| vec![c.tx_a.clone(), c.tx_b.clone()])
         .collect();
     drop(conflicts);
@@ -212,11 +213,13 @@ async fn submit_tx_handler(
                 arr.copy_from_slice(&b);
                 parents.push(arr);
             }
-            _ => return Json(TxResponse {
-                success: false,
-                tx_id: None,
-                error: Some(format!("Invalid parent hex: {}", p)),
-            }),
+            _ => {
+                return Json(TxResponse {
+                    success: false,
+                    tx_id: None,
+                    error: Some(format!("Invalid parent hex: {}", p)),
+                })
+            }
         }
     }
 
@@ -263,7 +266,12 @@ async fn submit_tx_handler(
     let nonce = pow.mine(&tx_header);
     let wire_tx = WireTransaction::new(tx, nonce);
     let tx_id_hex = hex::encode(&tx_id[..8]);
-    if state.cmd_tx.send(NodeCommand::BroadcastTx(wire_tx)).await.is_err() {
+    if state
+        .cmd_tx
+        .send(NodeCommand::BroadcastTx(wire_tx))
+        .await
+        .is_err()
+    {
         return Json(TxResponse {
             success: false,
             tx_id: None,
@@ -276,7 +284,6 @@ async fn submit_tx_handler(
         error: None,
     })
 }
-
 
 async fn trigger_conflict_handler(State(state): State<SharedState>) -> Json<ConflictResponse> {
     let sync = state.sync.lock().await;
@@ -347,15 +354,24 @@ async fn trigger_conflict_handler(State(state): State<SharedState>) -> Json<Conf
     let wire_blue = WireTransaction::new(tx_blue, nonce_blue);
     let tx_red_hex = hex::encode(&tx_red_id[..8]);
     let tx_blue_hex = hex::encode(&tx_blue_id[..8]);
-    info!("TRIGGERING CONFLICT: RED={} BLUE={}", tx_red_hex, tx_blue_hex);
-    let _ = state.cmd_tx.send(NodeCommand::TargetedBroadcast {
-        tx: wire_red.clone(),
-        target_peer: Some(0)
-    }).await;
-    let _ = state.cmd_tx.send(NodeCommand::TargetedBroadcast {
-        tx: wire_blue.clone(),
-        target_peer: Some(1)
-    }).await;
+    info!(
+        "TRIGGERING CONFLICT: RED={} BLUE={}",
+        tx_red_hex, tx_blue_hex
+    );
+    let _ = state
+        .cmd_tx
+        .send(NodeCommand::TargetedBroadcast {
+            tx: wire_red.clone(),
+            target_peer: Some(0),
+        })
+        .await;
+    let _ = state
+        .cmd_tx
+        .send(NodeCommand::TargetedBroadcast {
+            tx: wire_blue.clone(),
+            target_peer: Some(1),
+        })
+        .await;
     let mut sync = state.sync.lock().await;
     let _ = sync.receive_transaction(wire_red);
     let _ = sync.receive_transaction(wire_blue);
@@ -367,7 +383,6 @@ async fn trigger_conflict_handler(State(state): State<SharedState>) -> Json<Conf
         message: "Conflict injected. RED sent to peer 0, BLUE sent to peer 1.".into(),
     })
 }
-
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -443,32 +458,83 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let identity_state = shared_state.identity.clone();
     let identity_router = Router::new()
         // Identity endpoints
-        .route("/identity/register", post(identity_rpc::identity_register_handler))
+        .route(
+            "/identity/register",
+            post(identity_rpc::identity_register_handler),
+        )
         .route("/identity/:did", get(identity_rpc::identity_get_handler))
-        .route("/identity/:did", axum::routing::delete(identity_rpc::identity_deactivate_handler))
+        .route(
+            "/identity/:did",
+            axum::routing::delete(identity_rpc::identity_deactivate_handler),
+        )
         .route("/identity", get(identity_rpc::identity_list_handler))
         // Capability endpoints
-        .route("/capability/create", post(identity_rpc::capability_create_handler))
-        .route("/capability/delegate", post(identity_rpc::capability_delegate_handler))
-        .route("/capability/invoke", post(identity_rpc::capability_invoke_handler))
-        .route("/capability/revoke", post(identity_rpc::capability_revoke_handler))
-        .route("/capability/:cap_id_hex", get(identity_rpc::capability_get_handler))
-        .route("/capability/by-did/:did", get(identity_rpc::capability_list_by_did_handler))
+        .route(
+            "/capability/create",
+            post(identity_rpc::capability_create_handler),
+        )
+        .route(
+            "/capability/delegate",
+            post(identity_rpc::capability_delegate_handler),
+        )
+        .route(
+            "/capability/invoke",
+            post(identity_rpc::capability_invoke_handler),
+        )
+        .route(
+            "/capability/revoke",
+            post(identity_rpc::capability_revoke_handler),
+        )
+        .route(
+            "/capability/:cap_id_hex",
+            get(identity_rpc::capability_get_handler),
+        )
+        .route(
+            "/capability/by-did/:did",
+            get(identity_rpc::capability_list_by_did_handler),
+        )
         // Introduction endpoints
-        .route("/introduction", post(identity_rpc::introduction_create_handler))
-        .route("/introduction/chain/:from_did/:to_did", get(identity_rpc::introduction_chain_handler))
+        .route(
+            "/introduction",
+            post(identity_rpc::introduction_create_handler),
+        )
+        .route(
+            "/introduction/chain/:from_did/:to_did",
+            get(identity_rpc::introduction_chain_handler),
+        )
         // Coherence endpoints
-        .route("/coherence/:did", get(identity_rpc::coherence_profile_handler))
-        .route("/coherence/curvature/:did_a/:did_b", get(identity_rpc::coherence_curvature_handler))
-        .route("/coherence/neighbors/:did", get(identity_rpc::coherence_neighbors_handler))
+        .route(
+            "/coherence/:did",
+            get(identity_rpc::coherence_profile_handler),
+        )
+        .route(
+            "/coherence/curvature/:did_a/:did_b",
+            get(identity_rpc::coherence_curvature_handler),
+        )
+        .route(
+            "/coherence/neighbors/:did",
+            get(identity_rpc::coherence_neighbors_handler),
+        )
         // Petname endpoints
         .route("/petname", post(identity_rpc::petname_set_handler))
         .route("/petname/:name", get(identity_rpc::petname_resolve_handler))
         // Governance endpoints
-        .route("/governance/propose", post(identity_rpc::governance_propose_handler))
-        .route("/governance/vote", post(identity_rpc::governance_vote_handler))
-        .route("/governance/proposals", get(identity_rpc::governance_list_proposals_handler))
-        .route("/governance/:proposal_id_hex", get(identity_rpc::governance_get_proposal_handler))
+        .route(
+            "/governance/propose",
+            post(identity_rpc::governance_propose_handler),
+        )
+        .route(
+            "/governance/vote",
+            post(identity_rpc::governance_vote_handler),
+        )
+        .route(
+            "/governance/proposals",
+            get(identity_rpc::governance_list_proposals_handler),
+        )
+        .route(
+            "/governance/:proposal_id_hex",
+            get(identity_rpc::governance_get_proposal_handler),
+        )
         .with_state(identity_state);
 
     let app = Router::new()
@@ -533,9 +599,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             event = swarm.select_next_some() => {
                 handle_swarm_event(
-                    &mut swarm, 
-                    &shared_state, 
-                    &topic, 
+                    &mut swarm,
+                    &shared_state,
+                    &topic,
                     &mut connected_peers,
                     event
                 ).await;
@@ -543,7 +609,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 }
-
 
 fn create_genesis(sync: &mut SyncState) {
     // Generate a deterministic genesis keypair (for reproducibility)
@@ -579,7 +644,11 @@ fn create_genesis(sync: &mut SyncState) {
     info!("Genesis created: {}", hex::encode(&genesis_id[..8]));
 }
 
-fn mine_transaction(sync: &mut SyncState, height: &mut u64, peer_id: PeerId) -> Option<WireTransaction> {
+fn mine_transaction(
+    sync: &mut SyncState,
+    height: &mut u64,
+    peer_id: PeerId,
+) -> Option<WireTransaction> {
     let tips = sync.tips();
     // Need at least MIN_PARENTS=2 tips to mine a valid transaction
     if tips.len() < 2 {
@@ -630,10 +699,17 @@ fn mine_transaction(sync: &mut SyncState, height: &mut u64, peer_id: PeerId) -> 
     }
 }
 
-fn broadcast_tx(swarm: &mut Swarm<disentangle_p2p::DisentangleBehaviour>, topic: &IdentTopic, wire_tx: &WireTransaction) {
+fn broadcast_tx(
+    swarm: &mut Swarm<disentangle_p2p::DisentangleBehaviour>,
+    topic: &IdentTopic,
+    wire_tx: &WireTransaction,
+) {
     let msg = WireMessage::NewTransaction(wire_tx.clone());
     if let Ok(bytes) = msg.encode() {
-        let _ = swarm.behaviour_mut().gossipsub.publish(topic.clone(), bytes);
+        let _ = swarm
+            .behaviour_mut()
+            .gossipsub
+            .publish(topic.clone(), bytes);
     }
 }
 
@@ -650,14 +726,17 @@ fn handle_command(
         NodeCommand::TargetedBroadcast { tx, target_peer } => {
             if let Some(idx) = target_peer {
                 if let Some(peer) = peers.get(idx) {
-                    info!("Sending targeted tx {} to peer {}", hex::encode(&tx.tx.id[..8]), peer);
+                    info!(
+                        "Sending targeted tx {} to peer {}",
+                        hex::encode(&tx.tx.id[..8]),
+                        peer
+                    );
                 }
             }
             broadcast_tx(swarm, topic, &tx);
         }
     }
 }
-
 
 async fn handle_swarm_event(
     swarm: &mut Swarm<disentangle_p2p::DisentangleBehaviour>,
@@ -679,8 +758,14 @@ async fn handle_swarm_event(
             // If our DAG is empty, request tips from the new peer to sync genesis
             let dag_empty = state.sync.lock().await.transaction_count() == 0;
             if dag_empty {
-                info!("DAG empty, requesting tips from {} for genesis sync", peer_id);
-                swarm.behaviour_mut().request_response.send_request(&peer_id, DisentangleRequest::GetTips);
+                info!(
+                    "DAG empty, requesting tips from {} for genesis sync",
+                    peer_id
+                );
+                swarm
+                    .behaviour_mut()
+                    .request_response
+                    .send_request(&peer_id, DisentangleRequest::GetTips);
             }
         }
         SwarmEvent::ConnectionClosed { peer_id, .. } => {
@@ -690,24 +775,52 @@ async fn handle_swarm_event(
         }
         SwarmEvent::Behaviour(behaviour_event) => {
             match behaviour_event {
-                DisentangleBehaviourEvent::Gossipsub(gossipsub::Event::Message { message, propagation_source, .. }) => {
-                    handle_gossip_message(swarm, state, &message.data, propagation_source, topic, connected_peers).await;
+                DisentangleBehaviourEvent::Gossipsub(gossipsub::Event::Message {
+                    message,
+                    propagation_source,
+                    ..
+                }) => {
+                    handle_gossip_message(
+                        swarm,
+                        state,
+                        &message.data,
+                        propagation_source,
+                        topic,
+                        connected_peers,
+                    )
+                    .await;
                 }
-                DisentangleBehaviourEvent::RequestResponse(request_response::Event::Message { peer, message }) => {
-                    match message {
-                        request_response::Message::Request { request, channel, .. } => {
-                            handle_request(swarm, state, peer, request, channel).await;
-                        }
-                        request_response::Message::Response { request_id, response } => {
-                            handle_response(swarm, state, request_id, response, connected_peers).await;
-                        }
+                DisentangleBehaviourEvent::RequestResponse(request_response::Event::Message {
+                    peer,
+                    message,
+                }) => match message {
+                    request_response::Message::Request {
+                        request, channel, ..
+                    } => {
+                        handle_request(swarm, state, peer, request, channel).await;
                     }
-                }
-                DisentangleBehaviourEvent::Identify(identify::Event::Received { peer_id, info, .. }) => {
-                    debug!("Identify received from {}: {:?}", peer_id, info.listen_addrs);
+                    request_response::Message::Response {
+                        request_id,
+                        response,
+                    } => {
+                        handle_response(swarm, state, request_id, response, connected_peers).await;
+                    }
+                },
+                DisentangleBehaviourEvent::Identify(identify::Event::Received {
+                    peer_id,
+                    info,
+                    ..
+                }) => {
+                    debug!(
+                        "Identify received from {}: {:?}",
+                        peer_id, info.listen_addrs
+                    );
                     // Feed discovered addresses into Kademlia for DHT routing
                     for addr in &info.listen_addrs {
-                        swarm.behaviour_mut().kademlia.add_address(&peer_id, addr.clone());
+                        swarm
+                            .behaviour_mut()
+                            .kademlia
+                            .add_address(&peer_id, addr.clone());
                     }
                     // Trigger Kademlia bootstrap now that we know a peer
                     if let Err(e) = swarm.behaviour_mut().kademlia.bootstrap() {
@@ -724,7 +837,6 @@ async fn handle_swarm_event(
     }
 }
 
-
 async fn handle_gossip_message(
     swarm: &mut Swarm<disentangle_p2p::DisentangleBehaviour>,
     state: &SharedState,
@@ -735,7 +847,10 @@ async fn handle_gossip_message(
 ) {
     let msg = match WireMessage::decode(data) {
         Ok(m) => m,
-        Err(e) => { warn!("Decode error: {}", e); return; }
+        Err(e) => {
+            warn!("Decode error: {}", e);
+            return;
+        }
     };
     if let WireMessage::NewTransaction(wire_tx) = msg {
         let tx_id = wire_tx.tx.id;
@@ -745,7 +860,11 @@ async fn handle_gossip_message(
         let conflict = detect_conflict(&sync, &wire_tx.tx);
         match sync.receive_transaction(wire_tx.clone()) {
             SyncResult::Inserted => {
-                info!("📥 Inserted tx {} from gossip. DAG: {}", tx_id_hex, sync.transaction_count());
+                info!(
+                    "📥 Inserted tx {} from gossip. DAG: {}",
+                    tx_id_hex,
+                    sync.transaction_count()
+                );
                 if let Some(conflicting_id) = conflict {
                     drop(sync);
                     resolve_and_record_conflict(state, tx_id, conflicting_id).await;
@@ -755,13 +874,20 @@ async fn handle_gossip_message(
                 for parent_id in parents {
                     if let Some(peer) = peers.first() {
                         let request = DisentangleRequest::GetTransaction(parent_id);
-                        swarm.behaviour_mut().request_response.send_request(peer, request);
+                        swarm
+                            .behaviour_mut()
+                            .request_response
+                            .send_request(peer, request);
                     }
                 }
             }
             SyncResult::AlreadyHave | SyncResult::AlreadyPending => {}
-            SyncResult::InvalidPoW => { warn!("Invalid PoW from {}", source); }
-            SyncResult::BufferFull => { warn!("Buffer full"); }
+            SyncResult::InvalidPoW => {
+                warn!("Invalid PoW from {}", source);
+            }
+            SyncResult::BufferFull => {
+                warn!("Buffer full");
+            }
         }
     }
 }
@@ -769,17 +895,21 @@ async fn handle_gossip_message(
 fn detect_conflict(sync: &SyncState, new_tx: &Transaction) -> Option<NodeId> {
     let dag = sync.dag();
     for existing_id in dag.transaction_ids() {
-        if *existing_id == new_tx.id { continue; }
+        if *existing_id == new_tx.id {
+            continue;
+        }
         if let Some(existing) = dag.get(existing_id) {
             // v0.2: Compare ephemeral public keys to detect same-identity conflicts
             if existing.ephemeral_pk == new_tx.ephemeral_pk {
                 let shared_parents: HashSet<_> = existing.parents.iter().collect();
                 for p in &new_tx.parents {
                     if shared_parents.contains(p) {
-                        info!("CONFLICT DETECTED: {} vs {} (shared parent {})",
-                              hex::encode(&new_tx.id[..8]),
-                              hex::encode(&existing_id[..8]),
-                              hex::encode(&p[..8]));
+                        info!(
+                            "CONFLICT DETECTED: {} vs {} (shared parent {})",
+                            hex::encode(&new_tx.id[..8]),
+                            hex::encode(&existing_id[..8]),
+                            hex::encode(&p[..8])
+                        );
                         return Some(*existing_id);
                     }
                 }
@@ -789,7 +919,6 @@ fn detect_conflict(sync: &SyncState, new_tx: &Transaction) -> Option<NodeId> {
     None
 }
 
-
 async fn resolve_and_record_conflict(state: &SharedState, tx_a: NodeId, tx_b: NodeId) {
     let mut sync = state.sync.lock().await;
     let dag = sync.dag_mut();
@@ -798,10 +927,15 @@ async fn resolve_and_record_conflict(state: &SharedState, tx_a: NodeId, tx_b: No
         let tx_b_data = dag.get(&tx_b);
         match (tx_a_data, tx_b_data) {
             (Some(a), Some(b)) => {
-                let common: Vec<_> = a.parents.iter().filter(|p| b.parents.contains(p)).cloned().collect();
+                let common: Vec<_> = a
+                    .parents
+                    .iter()
+                    .filter(|p| b.parents.contains(p))
+                    .cloned()
+                    .collect();
                 common.first().cloned()
             }
-            _ => None
+            _ => None,
         }
     };
     let fork = match fork_point {
@@ -813,7 +947,10 @@ async fn resolve_and_record_conflict(state: &SharedState, tx_a: NodeId, tx_b: No
     };
     // v0.3: Use fork depth instead of fork block
     let fork_depth = dag.depth(&fork);
-    info!("⚖️  RESOLVING CONFLICT at fork point {}", hex::encode(&fork[..8]));
+    info!(
+        "⚖️  RESOLVING CONFLICT at fork point {}",
+        hex::encode(&fork[..8])
+    );
     let (winner, mass_a, mass_b) = resolve_conflict(dag, &tx_a, &tx_b, fork_depth);
     let winner_id = match winner {
         ConflictWinner::BranchA => tx_a,
@@ -821,8 +958,16 @@ async fn resolve_and_record_conflict(state: &SharedState, tx_a: NodeId, tx_b: No
     };
     info!("======================================");
     info!("🏆 CONFLICT RESOLVED!");
-    info!("   Branch A ({}): Mass {}", hex::encode(&tx_a[..8]), mass_a.total_mass as f64 / 65536.0);
-    info!("   Branch B ({}): Mass {}", hex::encode(&tx_b[..8]), mass_b.total_mass as f64 / 65536.0);
+    info!(
+        "   Branch A ({}): Mass {}",
+        hex::encode(&tx_a[..8]),
+        mass_a.total_mass as f64 / 65536.0
+    );
+    info!(
+        "   Branch B ({}): Mass {}",
+        hex::encode(&tx_b[..8]),
+        mass_b.total_mass as f64 / 65536.0
+    );
     info!("   WINNER: {}", hex::encode(&winner_id[..8]));
     info!("======================================");
     let timestamp = std::time::SystemTime::now()
@@ -856,18 +1001,20 @@ async fn handle_request(
                 Some(wire_tx) => DisentangleResponse::Transaction(wire_tx.encode().ok()),
                 None => DisentangleResponse::Transaction(None),
             };
-            let _ = swarm.behaviour_mut().request_response.send_response(channel, response);
+            let _ = swarm
+                .behaviour_mut()
+                .request_response
+                .send_response(channel, response);
         }
         DisentangleRequest::GetTips => {
             let sync = state.sync.lock().await;
-            let _ = swarm.behaviour_mut().request_response.send_response(
-                channel,
-                DisentangleResponse::Tips(sync.tips()),
-            );
+            let _ = swarm
+                .behaviour_mut()
+                .request_response
+                .send_response(channel, DisentangleResponse::Tips(sync.tips()));
         }
     }
 }
-
 
 async fn handle_response(
     swarm: &mut Swarm<disentangle_p2p::DisentangleBehaviour>,
@@ -882,10 +1029,10 @@ async fn handle_response(
             // Request each tip transaction to sync the DAG
             for tip_id in tip_ids {
                 if let Some(peer) = peers.first() {
-                    swarm.behaviour_mut().request_response.send_request(
-                        peer,
-                        DisentangleRequest::GetTransaction(tip_id),
-                    );
+                    swarm
+                        .behaviour_mut()
+                        .request_response
+                        .send_request(peer, DisentangleRequest::GetTransaction(tip_id));
                 }
             }
         }
@@ -898,7 +1045,10 @@ async fn handle_response(
                     for parent_id in more {
                         if let Some(peer) = peers.first() {
                             let request = DisentangleRequest::GetTransaction(parent_id);
-                            swarm.behaviour_mut().request_response.send_request(peer, request);
+                            swarm
+                                .behaviour_mut()
+                                .request_response
+                                .send_request(peer, request);
                         }
                     }
                 } else {

--- a/disentangle-p2p/src/bin/sybil_simulator.rs
+++ b/disentangle-p2p/src/bin/sybil_simulator.rs
@@ -146,7 +146,10 @@ fn main() -> Result<(), Box<dyn Error>> {
             )?;
         }
     }
-    println!("  ✓ Created {} edges (dense mesh)", honest_agents.len() * (honest_agents.len() - 1));
+    println!(
+        "  ✓ Created {} edges (dense mesh)",
+        honest_agents.len() * (honest_agents.len() - 1)
+    );
     println!();
 
     // Phase 2: Register Sybil identities (tree topology)
@@ -156,7 +159,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut sybil_leaves = Vec::new();
     for i in 0..args.sybil_count {
-        let agent = register_identity(&client, &args.node_url, "agi", &format!("sybil-leaf-{}", i))?;
+        let agent =
+            register_identity(&client, &args.node_url, "agi", &format!("sybil-leaf-{}", i))?;
         println!("  ✓ {} ({}...)", agent.name, &agent.did[..20]);
         sybil_leaves.push(agent);
     }
@@ -199,7 +203,10 @@ fn main() -> Result<(), Box<dyn Error>> {
             let tx_data = format!("{}-tx-{}", identity.name, tx_num);
             submit_transaction(&client, &args.node_url, &identity.did, parents, &tx_data)?;
         }
-        println!("  ✓ {} submitted {} transactions", identity.name, args.tx_per_identity);
+        println!(
+            "  ✓ {} submitted {} transactions",
+            identity.name, args.tx_per_identity
+        );
     }
     println!();
 
@@ -209,7 +216,10 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Query honest agents
     println!("=== HONEST AGENTS ===");
-    println!("{:<20} {:>10} {:>12} {:>10} {:>10}", "DID (short)", "Mass", "Curvature", "Diversity", "Score");
+    println!(
+        "{:<20} {:>10} {:>12} {:>10} {:>10}",
+        "DID (short)", "Mass", "Curvature", "Diversity", "Score"
+    );
     println!("{:-<64}", "");
 
     let mut honest_scores = Vec::new();
@@ -229,7 +239,10 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Query Sybil agents
     println!("=== SYBIL AGENTS ===");
-    println!("{:<20} {:>10} {:>12} {:>10} {:>10}", "DID (short)", "Mass", "Curvature", "Diversity", "Score");
+    println!(
+        "{:<20} {:>10} {:>12} {:>10} {:>10}",
+        "DID (short)", "Mass", "Curvature", "Diversity", "Score"
+    );
     println!("{:-<64}", "");
 
     let mut sybil_scores = Vec::new();

--- a/disentangle-p2p/src/bin/tx_generator.rs
+++ b/disentangle-p2p/src/bin/tx_generator.rs
@@ -148,9 +148,7 @@ struct Generator {
 
 impl Generator {
     fn new(node_url: String, num_senders: usize) -> Self {
-        let senders: Vec<String> = (0..num_senders)
-            .map(|i| format!("sender-{}", i))
-            .collect();
+        let senders: Vec<String> = (0..num_senders).map(|i| format!("sender-{}", i)).collect();
         let sender_sequences = vec![0; num_senders];
 
         Self {
@@ -182,9 +180,7 @@ impl Generator {
                     Err(e) => Err(format!("Failed to parse graph response: {}", e)),
                 }
             }
-            Err(e) => {
-                Err(format!("Failed to fetch graph: {}", e))
-            }
+            Err(e) => Err(format!("Failed to fetch graph: {}", e)),
         }
     }
 
@@ -279,9 +275,13 @@ impl Generator {
 
                     println!("\n=== Status Report ===");
                     println!("  Uptime: {}s", elapsed);
-                    println!("  Transactions sent: {} ({:.2} tx/s)", self.total_sent, rate);
+                    println!(
+                        "  Transactions sent: {} ({:.2} tx/s)",
+                        self.total_sent, rate
+                    );
                     println!("  Errors: {}", self.total_errors);
-                    println!("  DAG size: {} (Δ: +{})",
+                    println!(
+                        "  DAG size: {} (Δ: +{})",
                         status.dag_size,
                         status.dag_size.saturating_sub(self.last_dag_size)
                     );
@@ -308,7 +308,14 @@ impl Generator {
         println!("  Node: {}", self.node_url);
         println!("  Rate: {} tx/s", rate);
         println!("  Senders: {}", self.senders.len());
-        println!("  Target count: {}", if max_count == 0 { "unlimited".to_string() } else { max_count.to_string() });
+        println!(
+            "  Target count: {}",
+            if max_count == 0 {
+                "unlimited".to_string()
+            } else {
+                max_count.to_string()
+            }
+        );
         println!("\nPress Ctrl+C to stop.\n");
 
         let interval = Duration::from_secs_f64(1.0 / rate);
@@ -320,7 +327,8 @@ impl Generator {
         ctrlc::set_handler(move || {
             println!("\n\nShutting down gracefully...");
             r.store(false, Ordering::SeqCst);
-        }).expect("Error setting Ctrl+C handler");
+        })
+        .expect("Error setting Ctrl+C handler");
 
         // Wait for node to be ready
         println!("Waiting for node to be ready...");
@@ -349,7 +357,10 @@ impl Generator {
             }
 
             if max_count > 0 && self.total_sent >= max_count {
-                println!("\nTarget count reached: {} transactions sent", self.total_sent);
+                println!(
+                    "\nTarget count reached: {} transactions sent",
+                    self.total_sent
+                );
                 break;
             }
 
@@ -357,11 +368,9 @@ impl Generator {
             if Instant::now() >= next_tx {
                 match self.send_transaction() {
                     Ok(tx_id) => {
-                        println!("[{}] ✓ Sent tx {} (total: {}, errors: {})",
-                            self.total_sent,
-                            tx_id,
-                            self.total_sent,
-                            self.total_errors
+                        println!(
+                            "[{}] ✓ Sent tx {} (total: {}, errors: {})",
+                            self.total_sent, tx_id, self.total_sent, self.total_errors
                         );
                     }
                     Err(e) => {

--- a/disentangle-p2p/src/lib.rs
+++ b/disentangle-p2p/src/lib.rs
@@ -3,12 +3,12 @@
 //! P2P networking layer for Disentangle Protocol.
 //!
 //! ## Security Notes (v0.2)
-//! 
+//!
 //! The current implementation uses libp2p's Noise protocol with X25519.
 //! This is NOT post-quantum secure for transport encryption.
-//! 
+//!
 //! ### Migration Path to PQ Transport (v0.3)
-//! 
+//!
 //! Option A (Recommended): Implement hybrid key exchange after Noise handshake
 //! - Complete standard Noise-XX handshake (backward compatible)
 //! - Immediately re-key with Kyber1024 encapsulation
@@ -22,27 +22,28 @@
 //! that an attacker would need a quantum computer to break recorded sessions.
 //! The consensus layer (signatures, hashes) IS post-quantum secure.
 
-pub mod wire;
 pub mod behaviour;
-pub mod sync;
 pub mod pq_transport;
 pub mod pq_wrapper;
+pub mod sync;
+pub mod wire;
 
-pub use wire::{WireMessage, WireTransaction, GOSSIP_TOPIC, PROTOCOL_VERSION, PROTOCOL_VERSION_PQ, PQ_REKEY_PROTOCOL};
-pub use behaviour::{DisentangleBehaviour, DisentangleBehaviourEvent, DisentangleRequest, DisentangleResponse, PqUpgradeTracker};
-pub use sync::{SyncState, SyncResult};
+pub use behaviour::{
+    DisentangleBehaviour, DisentangleBehaviourEvent, DisentangleRequest, DisentangleResponse,
+    PqUpgradeTracker,
+};
 pub use pq_transport::{
-    PqRekeyMessage, PqRekeyError, PqSessionKeys,
-    derive_pq_session_keys_initiator, derive_pq_session_keys_responder,
+    derive_pq_session_keys_initiator, derive_pq_session_keys_responder, PqRekeyError,
+    PqRekeyMessage, PqSessionKeys,
 };
 pub use pq_wrapper::{PqEncryptedStream, PqEncryptionError};
-
-use libp2p::{
-    identity::Keypair,
-    noise, tcp, yamux,
-    SwarmBuilder,
-    Multiaddr, PeerId, Swarm,
+pub use sync::{SyncResult, SyncState};
+pub use wire::{
+    WireMessage, WireTransaction, GOSSIP_TOPIC, PQ_REKEY_PROTOCOL, PROTOCOL_VERSION,
+    PROTOCOL_VERSION_PQ,
 };
+
+use libp2p::{identity::Keypair, noise, tcp, yamux, Multiaddr, PeerId, Swarm, SwarmBuilder};
 use std::time::Duration;
 use tracing::info;
 
@@ -64,12 +65,8 @@ pub fn build_swarm(keypair: Keypair) -> Result<DisentangleSwarm, Box<dyn std::er
             yamux::Config::default,
         )?
         .with_dns()?
-        .with_behaviour(|_key| {
-            DisentangleBehaviour::new(local_peer_id, &keypair)
-        })?
-        .with_swarm_config(|cfg| {
-            cfg.with_idle_connection_timeout(Duration::from_secs(60))
-        })
+        .with_behaviour(|_key| DisentangleBehaviour::new(local_peer_id, &keypair))?
+        .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(60)))
         .build();
     Ok(swarm)
 }

--- a/disentangle-p2p/src/pq_transport.rs
+++ b/disentangle-p2p/src/pq_transport.rs
@@ -6,10 +6,10 @@
 
 use disentangle_crypto::hash::sha3_256_multi;
 use disentangle_crypto::kem::{
-    generate_kem_keypair, encapsulate, decapsulate,
-    EncapsulationKey, DecapsulationKey, Ciphertext, SharedSecret,
+    decapsulate, encapsulate, generate_kem_keypair, Ciphertext, DecapsulationKey, EncapsulationKey,
+    SharedSecret,
 };
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// Post-quantum re-keying protocol messages
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -17,7 +17,7 @@ pub enum PqRekeyMessage {
     /// Step 1: Initiator sends their encapsulation key
     Request {
         /// Initiator's ephemeral Kyber1024 encapsulation key
-        initiator_ek: Vec<u8>,  // 1568 bytes
+        initiator_ek: Vec<u8>, // 1568 bytes
         /// Random nonce for session binding
         nonce: [u8; 32],
         /// Protocol version for future upgrades
@@ -26,23 +26,21 @@ pub enum PqRekeyMessage {
     /// Step 2: Responder sends back both ciphertexts
     Response {
         /// Responder's ephemeral encapsulation key
-        responder_ek: Vec<u8>,  // 1568 bytes
+        responder_ek: Vec<u8>, // 1568 bytes
         /// Ciphertext encapsulating to initiator's key
-        initiator_ct: Vec<u8>,  // 1568 bytes
+        initiator_ct: Vec<u8>, // 1568 bytes
         /// Ciphertext encapsulating to responder's key (initiator will compute)
-        responder_ct: Vec<u8>,  // 1568 bytes
+        responder_ct: Vec<u8>, // 1568 bytes
     },
     /// Step 3: Initiator confirms key derivation succeeded
     Confirm {
         /// Ciphertext encapsulating to responder's key
-        responder_ct: Vec<u8>,  // 1568 bytes
+        responder_ct: Vec<u8>, // 1568 bytes
         /// MAC over (nonce || "PQ_REKEY_CONFIRM") using derived key
         confirmation_mac: [u8; 32],
     },
     /// Failure: one side couldn't complete re-key
-    Error {
-        reason: PqRekeyError,
-    },
+    Error { reason: PqRekeyError },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -80,8 +78,8 @@ pub struct PqSessionKeys {
 /// Combines both Kyber1024 shared secrets with the session nonce
 /// and derives separate keys for each direction using SHA3-256 with domain separation.
 pub fn derive_pq_session_keys_initiator(
-    initiator_ss: &SharedSecret,  // From responder encapsulating to initiator
-    responder_ss: &SharedSecret,  // From initiator encapsulating to responder
+    initiator_ss: &SharedSecret, // From responder encapsulating to initiator
+    responder_ss: &SharedSecret, // From initiator encapsulating to responder
     nonce: &[u8; 32],
 ) -> PqSessionKeys {
     // Combine both shared secrets with nonce
@@ -109,8 +107,8 @@ pub fn derive_pq_session_keys_initiator(
 /// Combines both Kyber1024 shared secrets with the session nonce
 /// and derives separate keys for each direction using SHA3-256 with domain separation.
 pub fn derive_pq_session_keys_responder(
-    initiator_ss: &SharedSecret,  // From responder encapsulating to initiator
-    responder_ss: &SharedSecret,  // From initiator encapsulating to responder
+    initiator_ss: &SharedSecret, // From responder encapsulating to initiator
+    responder_ss: &SharedSecret, // From initiator encapsulating to responder
     nonce: &[u8; 32],
 ) -> PqSessionKeys {
     // Combine both shared secrets with nonce
@@ -149,7 +147,11 @@ pub fn process_rekey_request(
     request: &PqRekeyMessage,
 ) -> Result<(PqRekeyMessage, DecapsulationKey, SharedSecret), PqRekeyError> {
     match request {
-        PqRekeyMessage::Request { initiator_ek, version, .. } => {
+        PqRekeyMessage::Request {
+            initiator_ek,
+            version,
+            ..
+        } => {
             if *version != 1 {
                 return Err(PqRekeyError::UnsupportedVersion);
             }
@@ -184,14 +186,18 @@ pub fn process_rekey_response(
     nonce: &[u8; 32],
 ) -> Result<(PqRekeyMessage, PqSessionKeys), PqRekeyError> {
     match response {
-        PqRekeyMessage::Response { responder_ek, initiator_ct, .. } => {
+        PqRekeyMessage::Response {
+            responder_ek,
+            initiator_ct,
+            ..
+        } => {
             // Parse responder's encapsulation key
             let responder_ek = EncapsulationKey::from_bytes(responder_ek)
                 .map_err(|_| PqRekeyError::InvalidKeyLength)?;
 
             // Decapsulate initiator_ct with our key
-            let initiator_ct = Ciphertext::from_bytes(initiator_ct)
-                .map_err(|_| PqRekeyError::InvalidKeyLength)?;
+            let initiator_ct =
+                Ciphertext::from_bytes(initiator_ct).map_err(|_| PqRekeyError::InvalidKeyLength)?;
             let initiator_ss = decapsulate(initiator_dk, &initiator_ct)
                 .map_err(|_| PqRekeyError::DecapsulationFailed)?;
 
@@ -202,11 +208,7 @@ pub fn process_rekey_response(
             let keys = derive_pq_session_keys_initiator(&initiator_ss, &responder_ss, nonce);
 
             // Create confirmation MAC
-            let confirmation_mac = sha3_256_multi(&[
-                &keys.send_key,
-                nonce,
-                b"PQ_REKEY_CONFIRM",
-            ]);
+            let confirmation_mac = sha3_256_multi(&[&keys.send_key, nonce, b"PQ_REKEY_CONFIRM"]);
 
             let confirm = PqRekeyMessage::Confirm {
                 responder_ct: responder_ct.to_bytes(),
@@ -230,10 +232,13 @@ pub fn verify_rekey_confirm(
     nonce: &[u8; 32],
 ) -> Result<PqSessionKeys, PqRekeyError> {
     match confirm {
-        PqRekeyMessage::Confirm { responder_ct, confirmation_mac } => {
+        PqRekeyMessage::Confirm {
+            responder_ct,
+            confirmation_mac,
+        } => {
             // Parse and decapsulate responder_ct to get responder_ss
-            let responder_ct = Ciphertext::from_bytes(responder_ct)
-                .map_err(|_| PqRekeyError::InvalidKeyLength)?;
+            let responder_ct =
+                Ciphertext::from_bytes(responder_ct).map_err(|_| PqRekeyError::InvalidKeyLength)?;
             let responder_ss = decapsulate(responder_dk, &responder_ct)
                 .map_err(|_| PqRekeyError::DecapsulationFailed)?;
 
@@ -241,11 +246,7 @@ pub fn verify_rekey_confirm(
             let keys = derive_pq_session_keys_responder(initiator_ss, &responder_ss, nonce);
 
             // Compute expected MAC (from responder's perspective, use recv_key)
-            let expected_mac = sha3_256_multi(&[
-                &keys.recv_key,
-                nonce,
-                b"PQ_REKEY_CONFIRM",
-            ]);
+            let expected_mac = sha3_256_multi(&[&keys.recv_key, nonce, b"PQ_REKEY_CONFIRM"]);
 
             if confirmation_mac == &expected_mac {
                 Ok(keys)
@@ -272,8 +273,16 @@ mod tests {
 
         match (&request, &deserialized) {
             (
-                PqRekeyMessage::Request { initiator_ek: ek1, nonce: n1, version: v1 },
-                PqRekeyMessage::Request { initiator_ek: ek2, nonce: n2, version: v2 },
+                PqRekeyMessage::Request {
+                    initiator_ek: ek1,
+                    nonce: n1,
+                    version: v1,
+                },
+                PqRekeyMessage::Request {
+                    initiator_ek: ek2,
+                    nonce: n2,
+                    version: v2,
+                },
             ) => {
                 assert_eq!(ek1, ek2);
                 assert_eq!(n1, n2);
@@ -302,7 +311,8 @@ mod tests {
         let ss1_recovered = decapsulate(&dk1, &ct1).unwrap();
         let ss2_recovered = decapsulate(&dk2, &ct2).unwrap();
 
-        let keys_recovered = derive_pq_session_keys_initiator(&ss1_recovered, &ss2_recovered, &nonce);
+        let keys_recovered =
+            derive_pq_session_keys_initiator(&ss1_recovered, &ss2_recovered, &nonce);
         assert_eq!(keys1.send_key, keys_recovered.send_key);
         assert_eq!(keys1.recv_key, keys_recovered.recv_key);
     }
@@ -340,12 +350,8 @@ mod tests {
             process_rekey_response(&response, &initiator_dk, &nonce).unwrap();
 
         // Responder verifies confirmation and derives session keys
-        let responder_keys = verify_rekey_confirm(
-            &confirm,
-            &responder_dk,
-            &initiator_ss_responder,
-            &nonce
-        ).unwrap();
+        let responder_keys =
+            verify_rekey_confirm(&confirm, &responder_dk, &initiator_ss_responder, &nonce).unwrap();
 
         // Verify keys match (initiator's send = responder's recv)
         assert_eq!(initiator_keys.send_key, responder_keys.recv_key);
@@ -388,13 +394,13 @@ mod tests {
         let initiator_keys = derive_pq_session_keys_initiator(
             &initiator_ss_by_initiator,
             &responder_ss_by_initiator,
-            &nonce
+            &nonce,
         );
 
         let responder_keys = derive_pq_session_keys_responder(
             &initiator_ss_by_responder,
             &responder_ss_by_responder,
-            &nonce
+            &nonce,
         );
 
         // Step 7: Verify keys match (send/recv are swapped)

--- a/disentangle-p2p/src/pq_wrapper.rs
+++ b/disentangle-p2p/src/pq_wrapper.rs
@@ -3,11 +3,8 @@
 //! Wraps an existing transport stream with ChaCha20-Poly1305 AEAD encryption
 //! using post-quantum derived session keys.
 
-use chacha20poly1305::{
-    ChaCha20Poly1305, KeyInit,
-    aead::Aead,
-};
 use chacha20poly1305::aead::generic_array::GenericArray;
+use chacha20poly1305::{aead::Aead, ChaCha20Poly1305, KeyInit};
 use thiserror::Error;
 
 /// Errors that can occur during PQ encryption/decryption
@@ -65,7 +62,8 @@ impl PqEncryptedStream {
         let nonce = self.create_nonce(self.send_nonce);
 
         // Encrypt with AEAD
-        let ciphertext = self.send_cipher
+        let ciphertext = self
+            .send_cipher
             .encrypt(&nonce, plaintext)
             .map_err(|_| PqEncryptionError::EncryptionFailed)?;
 
@@ -88,7 +86,8 @@ impl PqEncryptedStream {
         let nonce = self.create_nonce(self.recv_nonce);
 
         // Decrypt with AEAD
-        let plaintext = self.recv_cipher
+        let plaintext = self
+            .recv_cipher
             .decrypt(&nonce, ciphertext)
             .map_err(|_| PqEncryptionError::DecryptionFailed)?;
 
@@ -188,7 +187,7 @@ mod tests {
         let mut sender = PqEncryptedStream::new(&send_key, &recv_key);
         let mut receiver = PqEncryptedStream::new(&recv_key, &send_key);
 
-        let messages = vec![
+        let messages = [
             b"Message 1".to_vec(),
             b"Message 2".to_vec(),
             b"Message 3".to_vec(),

--- a/disentangle-p2p/src/sync.rs
+++ b/disentangle-p2p/src/sync.rs
@@ -3,11 +3,11 @@
 //! Implements "Recursive Pull" - when we receive a Tx but don't have
 //! its parents, we buffer the Tx and request the parents immediately.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use crate::wire::WireTransaction;
 use disentangle_dag::{NodeId, Transaction, TransactionDAG};
 use disentangle_node::HelloWorldPoW;
-use crate::wire::WireTransaction;
-use tracing::{debug, warn, info};
+use std::collections::{HashMap, HashSet, VecDeque};
+use tracing::{debug, info, warn};
 
 pub const MAX_PENDING_DEPTH: usize = 10;
 pub const MAX_PENDING_TXS: usize = 10000;
@@ -56,7 +56,6 @@ impl SyncState {
         self.dag.get(id).is_some() || self.pending.contains_key(id)
     }
 
-
     pub fn receive_transaction(&mut self, wire_tx: WireTransaction) -> SyncResult {
         let tx = &wire_tx.tx;
         let tx_id = tx.id;
@@ -88,7 +87,8 @@ impl SyncState {
                 warn!("Pending buffer full, dropping tx {:?}", &tx_id[..4]);
                 return SyncResult::BufferFull;
             }
-            let parents_to_request: Vec<NodeId> = missing.iter()
+            let parents_to_request: Vec<NodeId> = missing
+                .iter()
                 .filter(|p| {
                     let count = self.request_counts.get(*p).unwrap_or(&0);
                     *count < MAX_REQUESTS_PER_PARENT
@@ -100,15 +100,17 @@ impl SyncState {
                 self.waiting_for.entry(*parent).or_default().insert(tx_id);
             }
             debug!("Tx {:?} waiting for {} parents", &tx_id[..4], missing.len());
-            self.pending.insert(tx_id, PendingTx {
-                wire_tx,
-                missing_parents: missing,
-                depth: 0,
-            });
+            self.pending.insert(
+                tx_id,
+                PendingTx {
+                    wire_tx,
+                    missing_parents: missing,
+                    depth: 0,
+                },
+            );
             SyncResult::NeedParents(parents_to_request)
         }
     }
-
 
     fn insert_and_propagate(&mut self, wire_tx: WireTransaction) {
         let tx_id = wire_tx.tx.id;
@@ -163,11 +165,10 @@ impl SyncState {
         }
     }
 
-
     pub fn get_transaction(&self, id: &NodeId) -> Option<WireTransaction> {
-        self.dag.get(id).map(|tx| {
-            WireTransaction::new(tx.clone(), 0)
-        })
+        self.dag
+            .get(id)
+            .map(|tx| WireTransaction::new(tx.clone(), 0))
     }
 
     pub fn parent_not_found(&mut self, parent_id: &NodeId) {

--- a/disentangle-p2p/src/wire.rs
+++ b/disentangle-p2p/src/wire.rs
@@ -2,8 +2,8 @@
 //!
 //! Uses bincode for efficient binary serialization.
 
-use disentangle_dag::{Transaction, NodeId};
-use serde::{Serialize, Deserialize};
+use disentangle_dag::{NodeId, Transaction};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/disentangle-p2p/tests/e2e_network_test.rs
+++ b/disentangle-p2p/tests/e2e_network_test.rs
@@ -8,40 +8,27 @@
 //!
 //! Uses in-process nodes with virtual networking for deterministic testing.
 
-use disentangle_p2p::{
-    build_swarm, generate_keypair,
-    WireMessage, WireTransaction, SyncState, SyncResult,
-    DisentangleBehaviourEvent, DisentangleRequest, DisentangleResponse,
-    GOSSIP_TOPIC,
-};
-use disentangle_dag::{Transaction, NodeId};
 use disentangle_consensus::resolve_conflict;
-use disentangle_simhash::SimHash;
 use disentangle_crypto::{
-    generate_keypair as generate_dilithium_keypair,
-    sign as dilithium_sign,
-    sha3_256,
-    types::{Nullifier, Epoch},
+    generate_keypair as generate_dilithium_keypair, sha3_256, sign as dilithium_sign,
+    types::{Epoch, Nullifier},
 };
+use disentangle_dag::{NodeId, Transaction};
+use disentangle_p2p::{
+    build_swarm, generate_keypair, DisentangleBehaviourEvent, DisentangleRequest,
+    DisentangleResponse, SyncResult, SyncState, WireMessage, WireTransaction, GOSSIP_TOPIC,
+};
+use disentangle_simhash::SimHash;
 
-use libp2p::{
-    gossipsub::IdentTopic,
-    swarm::SwarmEvent,
-    futures::StreamExt,
-    Multiaddr, PeerId,
-};
+use libp2p::{futures::StreamExt, gossipsub::IdentTopic, swarm::SwarmEvent, Multiaddr, PeerId};
 use std::collections::HashSet;
 use std::time::Duration;
-use tokio::time::{timeout, sleep};
+use tokio::time::{sleep, timeout};
 
 const POW_DIFFICULTY: u8 = 8; // Lower difficulty for faster tests
 
 /// Create a test transaction with v0.3 structure
-fn create_test_transaction(
-    name: &str,
-    parents: Vec<NodeId>,
-    epoch_num: u64,
-) -> (Transaction, u64) {
+fn create_test_transaction(name: &str, parents: Vec<NodeId>, epoch_num: u64) -> (Transaction, u64) {
     let (signing_key, ephemeral_pk) = generate_dilithium_keypair();
 
     // History root derived from name for determinism
@@ -128,10 +115,16 @@ async fn test_sync_state_basic() {
     let genesis_wire = create_genesis();
     let genesis_id = genesis_wire.tx.id;
     let result = sync.receive_transaction(genesis_wire.clone());
-    assert!(matches!(result, SyncResult::Inserted), "Genesis should be inserted");
+    assert!(
+        matches!(result, SyncResult::Inserted),
+        "Genesis should be inserted"
+    );
 
     // Verify genesis is in DAG
-    assert!(sync.dag().get(&genesis_id).is_some(), "Genesis should be in DAG");
+    assert!(
+        sync.dag().get(&genesis_id).is_some(),
+        "Genesis should be in DAG"
+    );
 
     // Verify tips
     let tips = sync.tips();
@@ -140,7 +133,10 @@ async fn test_sync_state_basic() {
 
     // Try inserting again (should be AlreadyHave)
     let result = sync.receive_transaction(genesis_wire);
-    assert!(matches!(result, SyncResult::AlreadyHave), "Duplicate should return AlreadyHave");
+    assert!(
+        matches!(result, SyncResult::AlreadyHave),
+        "Duplicate should return AlreadyHave"
+    );
 
     println!("TEST PASSED: SyncState basic operations work correctly\n");
 }
@@ -167,8 +163,14 @@ async fn test_sync_state_chain() {
         let message = sha3_256(b"disentangle-test-genesis-b");
         let signature = dilithium_sign(&signing_key, &message);
         let mut genesis = Transaction {
-            id: [0u8; 32], ephemeral_pk, signature, parents: vec![],
-            simhash, nullifier, reputation_claim: 0, confidential_outputs: vec![],
+            id: [0u8; 32],
+            ephemeral_pk,
+            signature,
+            parents: vec![],
+            simhash,
+            nullifier,
+            reputation_claim: 0,
+            confidential_outputs: vec![],
         };
         genesis.id = genesis.compute_id();
         WireTransaction::new(genesis, 0)
@@ -179,20 +181,25 @@ async fn test_sync_state_chain() {
     // Build a chain of 5 transactions, each referencing genesis_a + previous tx
     let mut prev_id = genesis_b_id;
     for i in 1..=5 {
-        let (tx, nonce) = create_test_transaction(
-            &format!("tx_{}", i),
-            vec![genesis_a_id, prev_id],
-            i as u64,
-        );
+        let (tx, nonce) =
+            create_test_transaction(&format!("tx_{}", i), vec![genesis_a_id, prev_id], i as u64);
         let wire_tx = WireTransaction::new(tx.clone(), nonce);
         prev_id = tx.id;
 
         let result = sync.receive_transaction(wire_tx);
-        assert!(matches!(result, SyncResult::Inserted), "Transaction {} should be inserted", i);
+        assert!(
+            matches!(result, SyncResult::Inserted),
+            "Transaction {} should be inserted",
+            i
+        );
     }
 
     // Verify DAG size: 2 genesis + 5 chain = 7
-    assert_eq!(sync.transaction_count(), 7, "Should have 7 transactions (2 genesis + 5)");
+    assert_eq!(
+        sync.transaction_count(),
+        7,
+        "Should have 7 transactions (2 genesis + 5)"
+    );
 
     // Verify tip is the last transaction
     let tips = sync.tips();
@@ -224,8 +231,14 @@ async fn test_sync_state_missing_parents() {
         let message = sha3_256(b"disentangle-missing-parents-genesis-b");
         let signature = dilithium_sign(&signing_key, &message);
         let mut genesis = Transaction {
-            id: [0u8; 32], ephemeral_pk, signature, parents: vec![],
-            simhash, nullifier, reputation_claim: 0, confidential_outputs: vec![],
+            id: [0u8; 32],
+            ephemeral_pk,
+            signature,
+            parents: vec![],
+            simhash,
+            nullifier,
+            reputation_claim: 0,
+            confidential_outputs: vec![],
         };
         genesis.id = genesis.compute_id();
         WireTransaction::new(genesis, 0)
@@ -256,11 +269,18 @@ async fn test_sync_state_missing_parents() {
     // Now insert tx_1 - should trigger propagation of tx_2
     let wire_tx_1 = WireTransaction::new(tx_1, nonce_1);
     let result = sync.receive_transaction(wire_tx_1);
-    assert!(matches!(result, SyncResult::Inserted), "tx_1 should be inserted");
+    assert!(
+        matches!(result, SyncResult::Inserted),
+        "tx_1 should be inserted"
+    );
 
     // tx_2 should now be inserted automatically: 2 genesis + tx_1 + tx_2 = 4
     assert_eq!(sync.transaction_count(), 4, "Should have 4 transactions");
-    assert_eq!(sync.pending_count(), 0, "Should have 0 pending transactions");
+    assert_eq!(
+        sync.pending_count(),
+        0,
+        "Should have 0 pending transactions"
+    );
 
     println!("TEST PASSED: SyncState missing parent handling works correctly\n");
 }
@@ -287,8 +307,14 @@ async fn test_sync_state_fork_and_conflict() {
         let message = sha3_256(b"disentangle-fork-genesis-b");
         let signature = dilithium_sign(&signing_key, &message);
         let mut genesis = Transaction {
-            id: [0u8; 32], ephemeral_pk, signature, parents: vec![],
-            simhash, nullifier, reputation_claim: 0, confidential_outputs: vec![],
+            id: [0u8; 32],
+            ephemeral_pk,
+            signature,
+            parents: vec![],
+            simhash,
+            nullifier,
+            reputation_claim: 0,
+            confidential_outputs: vec![],
         };
         genesis.id = genesis.compute_id();
         WireTransaction::new(genesis, 0)
@@ -409,7 +435,8 @@ async fn test_swarm_creation() {
                 _ => continue,
             }
         }
-    }).await;
+    })
+    .await;
 
     assert!(result.is_ok(), "Should receive NewListenAddr event");
 
@@ -449,7 +476,9 @@ async fn test_two_node_connection() {
                 _ => continue,
             }
         }
-    }).await.expect("Node 1 should start listening");
+    })
+    .await
+    .expect("Node 1 should start listening");
 
     println!("Node 1 listening on: {}", node1_addr);
 
@@ -481,7 +510,8 @@ async fn test_two_node_connection() {
                 return true;
             }
         }
-    }).await;
+    })
+    .await;
 
     assert!(connected.is_ok(), "Nodes should connect");
     assert!(connected.unwrap(), "Both nodes should report connection");
@@ -523,7 +553,9 @@ async fn test_gossip_propagation() {
                 _ => continue,
             }
         }
-    }).await.expect("Node 1 should start listening");
+    })
+    .await
+    .expect("Node 1 should start listening");
 
     // Node 2 listens too (needed for gossipsub)
     let listen_addr2: Multiaddr = "/ip4/127.0.0.1/tcp/0".parse().unwrap();
@@ -537,7 +569,9 @@ async fn test_gossip_propagation() {
                 _ => continue,
             }
         }
-    }).await.expect("Node 2 should start listening");
+    })
+    .await
+    .expect("Node 2 should start listening");
 
     // Node 2 connects to node 1
     swarm2.dial(node1_addr).expect("Should dial");
@@ -559,7 +593,9 @@ async fn test_gossip_propagation() {
                 }
             }
         }
-    }).await.expect("Nodes should connect");
+    })
+    .await
+    .expect("Nodes should connect");
 
     println!("Nodes connected. Waiting for gossipsub mesh to form...");
 
@@ -584,7 +620,10 @@ async fn test_gossip_propagation() {
     let msg = WireMessage::NewTransaction(genesis_wire);
     let encoded = msg.encode().expect("Should encode");
 
-    let publish_result = swarm1.behaviour_mut().gossipsub.publish(topic.clone(), encoded.clone());
+    let publish_result = swarm1
+        .behaviour_mut()
+        .gossipsub
+        .publish(topic.clone(), encoded.clone());
     println!("Publish result: {:?}", publish_result);
 
     // Try to receive the message on node 2
@@ -606,17 +645,23 @@ async fn test_gossip_propagation() {
                 }
             }
         }
-    }).await;
+    })
+    .await;
 
     match received {
         Ok(received_id) => {
-            assert_eq!(received_id, genesis_id, "Received transaction ID should match");
+            assert_eq!(
+                received_id, genesis_id,
+                "Received transaction ID should match"
+            );
             println!("\nTEST PASSED: Gossip transaction propagation works correctly\n");
         }
         Err(_) => {
             // Gossipsub requires mesh formation which may not complete in test timing
             // This is expected behavior - mark as skipped rather than failed
-            println!("\nTEST SKIPPED: Gossipsub mesh did not form in time (expected in unit tests)\n");
+            println!(
+                "\nTEST SKIPPED: Gossipsub mesh did not form in time (expected in unit tests)\n"
+            );
             println!("NOTE: Full gossip testing requires integration test with longer timeouts\n");
         }
     }
@@ -651,7 +696,9 @@ async fn test_request_response_protocol() {
                 _ => continue,
             }
         }
-    }).await.expect("Node 1 should start listening");
+    })
+    .await
+    .expect("Node 1 should start listening");
 
     // Node 2 connects to node 1
     swarm2.dial(node1_addr).expect("Should dial");
@@ -668,12 +715,17 @@ async fn test_request_response_protocol() {
                 _event = swarm2.select_next_some() => {}
             }
         }
-    }).await.expect("Nodes should connect");
+    })
+    .await
+    .expect("Nodes should connect");
 
     println!("Nodes connected. Sending request...");
 
     // Node 2 sends GetTips request to node 1
-    swarm2.behaviour_mut().request_response.send_request(&peer_id1, DisentangleRequest::GetTips);
+    swarm2
+        .behaviour_mut()
+        .request_response
+        .send_request(&peer_id1, DisentangleRequest::GetTips);
 
     // Handle the request/response exchange
     let result = timeout(Duration::from_secs(10), async {
@@ -681,28 +733,24 @@ async fn test_request_response_protocol() {
             tokio::select! {
                 event = swarm1.select_next_some() => {
                     if let SwarmEvent::Behaviour(DisentangleBehaviourEvent::RequestResponse(
-                        libp2p::request_response::Event::Message { peer, message }
+                        libp2p::request_response::Event::Message { peer, message: libp2p::request_response::Message::Request { request, channel, .. } }
                     )) = event {
-                        if let libp2p::request_response::Message::Request { request, channel, .. } = message {
-                            println!("Node 1 received request from {}: {:?}", peer, request);
+                        println!("Node 1 received request from {}: {:?}", peer, request);
 
-                            // Send response
-                            let tips = vec![[0u8; 32], [1u8; 32]];
-                            let _ = swarm1.behaviour_mut().request_response.send_response(
-                                channel,
-                                DisentangleResponse::Tips(tips)
-                            );
-                        }
+                        // Send response
+                        let tips = vec![[0u8; 32], [1u8; 32]];
+                        let _ = swarm1.behaviour_mut().request_response.send_response(
+                            channel,
+                            DisentangleResponse::Tips(tips)
+                        );
                     }
                 }
                 event = swarm2.select_next_some() => {
                     if let SwarmEvent::Behaviour(DisentangleBehaviourEvent::RequestResponse(
-                        libp2p::request_response::Event::Message { message, .. }
+                        libp2p::request_response::Event::Message { message: libp2p::request_response::Message::Response { response, .. }, .. }
                     )) = event {
-                        if let libp2p::request_response::Message::Response { response, .. } = message {
-                            println!("Node 2 received response: {:?}", response);
-                            return response;
-                        }
+                        println!("Node 2 received response: {:?}", response);
+                        return response;
                     }
                 }
             }

--- a/disentangle-simhash/src/lib.rs
+++ b/disentangle-simhash/src/lib.rs
@@ -1,13 +1,13 @@
 //! # Entangle SimHash v0.2
-//! 
+//!
 //! Locality-sensitive hashing for Proof of Entanglement with STRICT STRUCTURAL BINDING.
-//! 
+//!
 //! ## Security Invariant
-//! 
+//!
 //! The SimHash MUST be derived ONLY from:
 //! 1. Parent transaction hashes (environmental influence)
 //! 2. Identity history Merkle root (genetic influence)
-//! 
+//!
 //! NO user-controllable content (memo fields, output data, etc.) may influence
 //! the SimHash. This prevents "grinding attacks" where an attacker generates
 //! random transaction content to find a favorable topological position.
@@ -17,9 +17,9 @@
 //! - Added `from_structural()` - only structural inputs accepted
 //! - SHA2 → SHA3-256 for quantum resistance
 
-use sha3::{Sha3_256, Digest};
-use serde::{Serialize, Deserialize};
 use disentangle_crypto::hash::Hash256;
+use serde::{Deserialize, Serialize};
+use sha3::{Digest, Sha3_256};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SimHash(pub u128);
@@ -27,13 +27,13 @@ pub struct SimHash(pub u128);
 impl SimHash {
     pub const ZERO: SimHash = SimHash(0);
     pub const BITS: u32 = 128;
-    
+
     /// Compute SimHash from STRUCTURAL INPUTS ONLY.
-    /// 
+    ///
     /// # Arguments
     /// * `parent_hashes` - Hashes of parent transactions (DAG edges)
     /// * `identity_history_root` - Merkle root of sender's transaction history
-    /// 
+    ///
     /// # Security
     /// This function accepts NO user-controllable data. The sender's topological
     /// position is determined entirely by their history and their chosen parents.
@@ -42,7 +42,7 @@ impl SimHash {
         let structural_seed = sha3_combine(&parent_combined, identity_history_root);
         Self::generate_from_seed(&structural_seed)
     }
-    
+
     /// Combine parent SimHashes using majority voting.
     /// Used to compute environmental influence from parent transactions.
     pub fn combine_simhashes(hashes: &[SimHash]) -> SimHash {
@@ -58,21 +58,21 @@ impl SimHash {
         }
         SimHash(result)
     }
-    
+
     /// Hamming distance between two SimHashes.
     /// Lower distance = more similar topological position.
     pub fn hamming_distance(&self, other: &SimHash) -> u32 {
         (self.0 ^ other.0).count_ones()
     }
-    
+
     /// Check if two SimHashes are within coherence threshold.
     pub fn is_coherent(&self, other: &SimHash, threshold: u32) -> bool {
         self.hamming_distance(other) <= threshold
     }
-    
+
     /// Apply bounded drift to SimHash.
     /// Used for natural evolution of position over time.
-    /// 
+    ///
     /// # Arguments
     /// * `seed` - Deterministic seed derived from structural data
     /// * `drift_bits` - Maximum bits allowed to flip
@@ -86,7 +86,7 @@ impl SimHash {
         let mask = create_sparse_mask(noise, drift_bits);
         SimHash(self.0 ^ mask)
     }
-    
+
     fn combine_parent_hashes(parent_hashes: &[Hash256]) -> Hash256 {
         let mut hasher = Sha3_256::new();
         hasher.update(b"PARENT_COMBINE_V2");
@@ -99,7 +99,7 @@ impl SimHash {
         out.copy_from_slice(&result);
         out
     }
-    
+
     fn generate_from_seed(seed: &Hash256) -> Self {
         let mut weights = [0i32; 128];
         let mut hasher = Sha3_256::new();
@@ -241,9 +241,12 @@ mod tests {
         let history = test_hash(100);
         let h1 = SimHash::from_structural(&parents, &history);
         let h2 = SimHash::from_structural(&parents, &history);
-        assert_eq!(h1, h2, "SimHash should be identical regardless of any user data");
+        assert_eq!(
+            h1, h2,
+            "SimHash should be identical regardless of any user data"
+        );
     }
-    
+
     #[test]
     fn test_grinding_resistance() {
         let history = test_hash(100);
@@ -252,7 +255,13 @@ mod tests {
             let parents = vec![test_hash(i)];
             hashes.push(SimHash::from_structural(&parents, &history));
         }
-        let unique_count = hashes.iter().collect::<std::collections::HashSet<_>>().len();
-        assert_eq!(unique_count, 100, "Each unique parent set should produce unique SimHash");
+        let unique_count = hashes
+            .iter()
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        assert_eq!(
+            unique_count, 100,
+            "Each unique parent set should produce unique SimHash"
+        );
     }
 }

--- a/disentangle-zkp/src/balance_circuit.rs
+++ b/disentangle-zkp/src/balance_circuit.rs
@@ -3,12 +3,12 @@
 //! Proves: Sum(input_amounts) == Sum(output_amounts)
 //! Without revealing the actual amounts.
 
+use crate::confidential::{AmountCommitment, Blinding};
 use p3_air::{Air, AirBuilder, BaseAir};
-use p3_field::{Field, AbstractField};
 use p3_baby_bear::BabyBear;
+use p3_field::{AbstractField, Field};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
-use crate::confidential::{AmountCommitment, Blinding};
 
 /// Maximum number of inputs/outputs supported per transaction.
 pub const MAX_IO_COUNT: usize = 8;
@@ -26,7 +26,10 @@ pub struct BalanceAir {
 
 impl Default for BalanceAir {
     fn default() -> Self {
-        Self { num_inputs: 2, num_outputs: 2 }
+        Self {
+            num_inputs: 2,
+            num_outputs: 2,
+        }
     }
 }
 
@@ -82,10 +85,7 @@ pub struct BalanceWitness {
 impl BalanceWitness {
     /// Create a new balance witness.
     /// Returns None if balance doesn't conserve.
-    pub fn new(
-        inputs: Vec<(u64, Blinding)>,
-        outputs: Vec<(u64, Blinding)>,
-    ) -> Option<Self> {
+    pub fn new(inputs: Vec<(u64, Blinding)>, outputs: Vec<(u64, Blinding)>) -> Option<Self> {
         let input_sum: u64 = inputs.iter().map(|(a, _)| a).sum();
         let output_sum: u64 = outputs.iter().map(|(a, _)| a).sum();
 
@@ -158,14 +158,8 @@ mod tests {
 
     #[test]
     fn test_balance_witness_valid() {
-        let inputs = vec![
-            (1000u64, [1u8; 32]),
-            (500u64, [2u8; 32]),
-        ];
-        let outputs = vec![
-            (800u64, [3u8; 32]),
-            (700u64, [4u8; 32]),
-        ];
+        let inputs = vec![(1000u64, [1u8; 32]), (500u64, [2u8; 32])];
+        let outputs = vec![(800u64, [3u8; 32]), (700u64, [4u8; 32])];
 
         let witness = BalanceWitness::new(inputs, outputs);
         assert!(witness.is_some());
@@ -179,9 +173,7 @@ mod tests {
 
     #[test]
     fn test_balance_witness_invalid() {
-        let inputs = vec![
-            (1000u64, [1u8; 32]),
-        ];
+        let inputs = vec![(1000u64, [1u8; 32])];
         let outputs = vec![
             (999u64, [2u8; 32]), // Doesn't balance!
         ];
@@ -192,13 +184,8 @@ mod tests {
 
     #[test]
     fn test_trace_generation() {
-        let inputs = vec![
-            (500u64, [5u8; 32]),
-            (300u64, [6u8; 32]),
-        ];
-        let outputs = vec![
-            (800u64, [7u8; 32]),
-        ];
+        let inputs = vec![(500u64, [5u8; 32]), (300u64, [6u8; 32])];
+        let outputs = vec![(800u64, [7u8; 32])];
 
         let witness = BalanceWitness::new(inputs, outputs).unwrap();
         let trace = witness.generate_trace();

--- a/disentangle-zkp/src/circuit.rs
+++ b/disentangle-zkp/src/circuit.rs
@@ -20,10 +20,10 @@
 //! 3. account_state.reputation_score >= reputation_threshold
 
 use p3_air::{Air, AirBuilder, BaseAir};
-use p3_field::{Field, AbstractField};
+use p3_baby_bear::BabyBear;
+use p3_field::{AbstractField, Field};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
-use p3_baby_bear::BabyBear;
 
 /// Width of the execution trace (number of columns).
 /// We need columns for:
@@ -44,7 +44,9 @@ pub struct ReputationAir {
 
 impl Default for ReputationAir {
     fn default() -> Self {
-        Self { num_rows: MAX_TREE_DEPTH }
+        Self {
+            num_rows: MAX_TREE_DEPTH,
+        }
     }
 }
 
@@ -88,7 +90,7 @@ impl<AB: AirBuilder> Air<AB> for ReputationAir {
         // Full implementation would use range proofs
         let is_last = local[9];
         builder.when(is_last).assert_zero(
-            reputation - threshold - local[10] // diff stored in workspace
+            reputation - threshold - local[10], // diff stored in workspace
         );
 
         // Constraint 3: Hash chain continuity

--- a/disentangle-zkp/src/confidential.rs
+++ b/disentangle-zkp/src/confidential.rs
@@ -3,7 +3,7 @@
 //! Uses SHA3-256 for post-quantum security (collision-resistant binding).
 
 use disentangle_crypto::hash::{sha3_256_multi, Hash256};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 pub const BLINDING_BYTES: usize = 32;
 pub type Blinding = [u8; BLINDING_BYTES];
@@ -20,11 +20,7 @@ impl AmountCommitment {
     /// * `amount` - The amount being committed (in smallest units)
     /// * `blinding` - 32-byte random blinding factor (must be kept secret)
     pub fn commit(amount: u64, blinding: &Blinding) -> Self {
-        let hash = sha3_256_multi(&[
-            b"AMOUNT_COMMIT_V1",
-            &amount.to_le_bytes(),
-            blinding,
-        ]);
+        let hash = sha3_256_multi(&[b"AMOUNT_COMMIT_V1", &amount.to_le_bytes(), blinding]);
         Self(hash)
     }
 

--- a/disentangle-zkp/src/lib.rs
+++ b/disentangle-zkp/src/lib.rs
@@ -33,24 +33,26 @@
 //! ConfidentialTx --> BalanceCircuit + RangeCircuit --> ZkProof
 //! ```
 
-pub mod merkle;
-pub mod types;
-pub mod circuit;
-pub mod proof;
-pub mod confidential;
 pub mod balance_circuit;
+pub mod circuit;
+pub mod confidential;
+pub mod merkle;
+pub mod proof;
 pub mod range_circuit;
-pub mod stealth;
 pub mod reputation_bucket;
+pub mod stealth;
+pub mod types;
 
-pub use merkle::{AccountMerkleTree, MerkleProof};
-pub use types::{ReputationClaim, AccountStateLeaf, SupporterTag, DiversityAwareReputationClaim};
-pub use proof::{ReputationProver, ReputationVerifier};
-pub use confidential::{AmountCommitment, ConfidentialAmount, Blinding};
 pub use balance_circuit::{BalanceAir, BalanceWitness};
+pub use confidential::{AmountCommitment, Blinding, ConfidentialAmount};
+pub use merkle::{AccountMerkleTree, MerkleProof};
+pub use proof::{ReputationProver, ReputationVerifier};
 pub use range_circuit::{RangeAir, RangeWitness};
-pub use stealth::{StealthAddress, ConfidentialOutput, StealthError};
-pub use reputation_bucket::{ReputationBucket, BUCKET_WEIGHTS, reputation_to_bucket, bucket_weight};
+pub use reputation_bucket::{
+    bucket_weight, reputation_to_bucket, ReputationBucket, BUCKET_WEIGHTS,
+};
+pub use stealth::{ConfidentialOutput, StealthAddress, StealthError};
+pub use types::{AccountStateLeaf, DiversityAwareReputationClaim, ReputationClaim, SupporterTag};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ZkpError {

--- a/disentangle-zkp/src/merkle.rs
+++ b/disentangle-zkp/src/merkle.rs
@@ -7,7 +7,7 @@
 use crate::types::AccountStateLeaf;
 use crate::ZkpError;
 use disentangle_crypto::hash::{sha3_256_multi, Hash256};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// A Merkle proof of membership for an account state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -200,10 +200,7 @@ mod tests {
 
     #[test]
     fn test_merkle_proof_invalid_root() {
-        let accounts = vec![
-            make_test_account(1, 100),
-            make_test_account(2, 200),
-        ];
+        let accounts = vec![make_test_account(1, 100), make_test_account(2, 200)];
         let tree = AccountMerkleTree::new(&accounts);
         let proof = tree.prove_membership(0).unwrap();
 
@@ -214,10 +211,7 @@ mod tests {
 
     #[test]
     fn test_merkle_root_determinism() {
-        let accounts = vec![
-            make_test_account(1, 100),
-            make_test_account(2, 200),
-        ];
+        let accounts = vec![make_test_account(1, 100), make_test_account(2, 200)];
         let tree1 = AccountMerkleTree::new(&accounts);
         let tree2 = AccountMerkleTree::new(&accounts);
         assert_eq!(tree1.root(), tree2.root());

--- a/disentangle-zkp/src/proof.rs
+++ b/disentangle-zkp/src/proof.rs
@@ -6,7 +6,7 @@
 use crate::circuit::{ReputationAir, ReputationWitness};
 use crate::merkle::AccountMerkleTree;
 use crate::types::{AccountStateLeaf, ReputationClaim};
-use crate::{ZkpError, Result};
+use crate::{Result, ZkpError};
 use disentangle_crypto::hash::Hash256;
 
 use p3_matrix::Matrix;
@@ -180,18 +180,16 @@ fn verify_merkle_path(witness: &ReputationWitness) -> bool {
 
 /// Serialize witness as proof (placeholder for actual STARK proof).
 fn serialize_witness_as_proof(witness: &ReputationWitness) -> Result<Vec<u8>> {
-    bincode::serialize(witness)
-        .map_err(|e| ZkpError::SerializationError(e.to_string()))
+    bincode::serialize(witness).map_err(|e| ZkpError::SerializationError(e.to_string()))
 }
 
 /// Deserialize witness from proof (placeholder for actual STARK verification).
 fn deserialize_witness_from_proof(data: &[u8]) -> Result<ReputationWitness> {
-    bincode::deserialize(data)
-        .map_err(|e| ZkpError::SerializationError(e.to_string()))
+    bincode::deserialize(data).map_err(|e| ZkpError::SerializationError(e.to_string()))
 }
 
 // Add Serialize/Deserialize to ReputationWitness for the placeholder impl
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 impl Serialize for ReputationWitness {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -203,7 +201,14 @@ impl Serialize for ReputationWitness {
         s.serialize_field("reputation_score", &self.reputation_score)?;
         s.serialize_field("threshold", &self.threshold)?;
         s.serialize_field("leaf_hash", &self.leaf_hash.to_vec())?;
-        s.serialize_field("merkle_siblings", &self.merkle_siblings.iter().map(|h| h.to_vec()).collect::<Vec<_>>())?;
+        s.serialize_field(
+            "merkle_siblings",
+            &self
+                .merkle_siblings
+                .iter()
+                .map(|h| h.to_vec())
+                .collect::<Vec<_>>(),
+        )?;
         s.serialize_field("path_bits", &self.path_bits)?;
         s.serialize_field("merkle_root", &self.merkle_root.to_vec())?;
         s.end()
@@ -227,13 +232,21 @@ impl<'de> Deserialize<'de> for ReputationWitness {
 
         let helper = Helper::deserialize(deserializer)?;
 
-        let leaf_hash: [u8; 32] = helper.leaf_hash.try_into()
+        let leaf_hash: [u8; 32] = helper
+            .leaf_hash
+            .try_into()
             .map_err(|_| serde::de::Error::custom("invalid leaf_hash length"))?;
-        let merkle_root: [u8; 32] = helper.merkle_root.try_into()
+        let merkle_root: [u8; 32] = helper
+            .merkle_root
+            .try_into()
             .map_err(|_| serde::de::Error::custom("invalid merkle_root length"))?;
-        let merkle_siblings: Vec<[u8; 32]> = helper.merkle_siblings
+        let merkle_siblings: Vec<[u8; 32]> = helper
+            .merkle_siblings
             .into_iter()
-            .map(|v| v.try_into().map_err(|_| serde::de::Error::custom("invalid sibling length")))
+            .map(|v| {
+                v.try_into()
+                    .map_err(|_| serde::de::Error::custom("invalid sibling length"))
+            })
             .collect::<std::result::Result<_, _>>()?;
 
         Ok(ReputationWitness {
@@ -281,7 +294,10 @@ mod tests {
 
         // Account 2 has reputation 50, try to prove >= 100
         let result = prover.prove(2, &accounts[2], 100, 1);
-        assert!(matches!(result, Err(ZkpError::InsufficientReputation { .. })));
+        assert!(matches!(
+            result,
+            Err(ZkpError::InsufficientReputation { .. })
+        ));
     }
 
     #[test]

--- a/disentangle-zkp/src/range_circuit.rs
+++ b/disentangle-zkp/src/range_circuit.rs
@@ -4,8 +4,8 @@
 //! Uses bit decomposition approach.
 
 use p3_air::{Air, AirBuilder, BaseAir};
-use p3_field::{Field, AbstractField};
 use p3_baby_bear::BabyBear;
+use p3_field::{AbstractField, Field};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 
@@ -68,7 +68,11 @@ impl RangeWitness {
 
         for (i, trace_bit) in trace.iter_mut().enumerate().take(RANGE_BITS) {
             let bit = (self.value >> i) & 1;
-            *trace_bit = if bit == 1 { BabyBear::one() } else { BabyBear::zero() };
+            *trace_bit = if bit == 1 {
+                BabyBear::one()
+            } else {
+                BabyBear::zero()
+            };
             if bit == 1 {
                 reconstructed += power_of_two;
             }
@@ -98,9 +102,9 @@ mod tests {
 
         // Check bit decomposition of 42 = 0b101010
         let row: Vec<_> = trace.row(0).collect();
-        assert_eq!(row[1], BabyBear::one());  // bit 1
-        assert_eq!(row[3], BabyBear::one());  // bit 3
-        assert_eq!(row[5], BabyBear::one());  // bit 5
+        assert_eq!(row[1], BabyBear::one()); // bit 1
+        assert_eq!(row[3], BabyBear::one()); // bit 3
+        assert_eq!(row[5], BabyBear::one()); // bit 5
         assert_eq!(row[0], BabyBear::zero()); // bit 0
         assert_eq!(row[2], BabyBear::zero()); // bit 2
     }
@@ -112,8 +116,8 @@ mod tests {
 
         // All bits should be 1
         let row: Vec<_> = trace.row(0).collect();
-        for i in 0..RANGE_BITS {
-            assert_eq!(row[i], BabyBear::one());
+        for bit in row.iter().take(RANGE_BITS) {
+            assert_eq!(*bit, BabyBear::one());
         }
     }
 
@@ -124,8 +128,8 @@ mod tests {
 
         // All bits should be 0
         let row: Vec<_> = trace.row(0).collect();
-        for i in 0..RANGE_BITS {
-            assert_eq!(row[i], BabyBear::zero());
+        for bit in row.iter().take(RANGE_BITS) {
+            assert_eq!(*bit, BabyBear::zero());
         }
 
         // Original and reconstructed should both be 0
@@ -141,11 +145,11 @@ mod tests {
 
         let row: Vec<_> = trace.row(0).collect();
         // Only bit 8 should be set
-        for i in 0..RANGE_BITS {
+        for (i, bit) in row.iter().enumerate().take(RANGE_BITS) {
             if i == 8 {
-                assert_eq!(row[i], BabyBear::one());
+                assert_eq!(*bit, BabyBear::one());
             } else {
-                assert_eq!(row[i], BabyBear::zero());
+                assert_eq!(*bit, BabyBear::zero());
             }
         }
     }

--- a/disentangle-zkp/src/stealth.rs
+++ b/disentangle-zkp/src/stealth.rs
@@ -2,13 +2,12 @@
 //!
 //! Allows sending to recipients without revealing their public key on-chain.
 
-use disentangle_crypto::kem::{
-    EncapsulationKey, DecapsulationKey, Ciphertext, SharedSecret,
-    encapsulate, decapsulate,
-};
-use disentangle_crypto::hash::{sha3_256_multi, Hash256};
-use serde::{Serialize, Deserialize};
 use crate::confidential::AmountCommitment;
+use disentangle_crypto::hash::{sha3_256_multi, Hash256};
+use disentangle_crypto::kem::{
+    decapsulate, encapsulate, Ciphertext, DecapsulationKey, EncapsulationKey, SharedSecret,
+};
+use serde::{Deserialize, Serialize};
 
 /// A stealth address derived from a KEM shared secret.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -17,11 +16,7 @@ pub struct StealthAddress(pub Hash256);
 impl StealthAddress {
     /// Derive a stealth address from a shared secret.
     fn from_shared_secret(shared_secret: &SharedSecret, domain: &[u8]) -> Self {
-        let hash = sha3_256_multi(&[
-            b"STEALTH_ADDR_V1",
-            domain,
-            shared_secret.as_bytes(),
-        ]);
+        let hash = sha3_256_multi(&[b"STEALTH_ADDR_V1", domain, shared_secret.as_bytes()]);
         Self(hash)
     }
 
@@ -58,8 +53,8 @@ pub fn recover_stealth_address(
     recipient_dk: &DecapsulationKey,
     ciphertext: &Ciphertext,
 ) -> Result<(StealthAddress, SharedSecret), StealthError> {
-    let shared_secret = decapsulate(recipient_dk, ciphertext)
-        .map_err(|_| StealthError::DecapsulationFailed)?;
+    let shared_secret =
+        decapsulate(recipient_dk, ciphertext).map_err(|_| StealthError::DecapsulationFailed)?;
     let stealth_addr = StealthAddress::from_shared_secret(&shared_secret, b"");
     Ok((stealth_addr, shared_secret))
 }
@@ -84,11 +79,7 @@ impl ConfidentialOutput {
     /// * `amount` - The amount to send
     /// * `blinding` - Random blinding factor for commitment
     /// * `recipient_ek` - Recipient's encapsulation key
-    pub fn new(
-        amount: u64,
-        blinding: [u8; 32],
-        recipient_ek: &EncapsulationKey,
-    ) -> Self {
+    pub fn new(amount: u64, blinding: [u8; 32], recipient_ek: &EncapsulationKey) -> Self {
         let commitment = AmountCommitment::commit(amount, &blinding);
         let (stealth_address, ephemeral_ciphertext, shared_secret) =
             generate_stealth_address(recipient_ek);
@@ -239,7 +230,7 @@ mod tests {
 
         assert!(result.is_err());
         match result {
-            Err(StealthError::NotForRecipient) => {},
+            Err(StealthError::NotForRecipient) => {}
             _ => panic!("Expected NotForRecipient error"),
         }
     }
@@ -265,7 +256,7 @@ mod tests {
         let result = decrypt_amount(&wrong_data, &key);
         assert!(result.is_err());
         match result {
-            Err(StealthError::InvalidEncryptedData) => {},
+            Err(StealthError::InvalidEncryptedData) => {}
             _ => panic!("Expected InvalidEncryptedData error"),
         }
     }

--- a/disentangle-zkp/src/types.rs
+++ b/disentangle-zkp/src/types.rs
@@ -1,7 +1,7 @@
 //! Core types for zero-knowledge reputation proofs.
 
 use disentangle_crypto::hash::Hash256;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// Leaf data for account state in Merkle tree.
 /// This is what gets hashed to create leaf nodes.

--- a/disentangle-zkp/tests/confidential_integration.rs
+++ b/disentangle-zkp/tests/confidential_integration.rs
@@ -1,11 +1,8 @@
 //! Integration tests for Phase 4: Confidential Transactions
 
-use disentangle_zkp::{
-    AmountCommitment, BalanceWitness, RangeWitness,
-    ConfidentialOutput,
-};
-use disentangle_zkp::stealth::generate_stealth_address;
 use disentangle_crypto::kem::generate_kem_keypair;
+use disentangle_zkp::stealth::generate_stealth_address;
+use disentangle_zkp::{AmountCommitment, BalanceWitness, ConfidentialOutput, RangeWitness};
 use p3_matrix::Matrix;
 
 #[test]
@@ -62,32 +59,38 @@ fn test_full_confidential_transaction_flow() {
     assert_eq!(range_trace_2.width(), 66);
 
     // Step 5: Create confidential outputs with stealth addresses
-    let conf_output_to_bob = ConfidentialOutput::new(
-        output1_amount,
-        output1_blinding,
-        &bob_ek,
-    );
+    let conf_output_to_bob = ConfidentialOutput::new(output1_amount, output1_blinding, &bob_ek);
 
-    let conf_output_to_alice = ConfidentialOutput::new(
-        output2_amount,
-        output2_blinding,
-        &alice_ek,
-    );
+    let conf_output_to_alice = ConfidentialOutput::new(output2_amount, output2_blinding, &alice_ek);
 
     // Step 6: Bob tries to decrypt his output
     let bob_result = conf_output_to_bob.try_decrypt(&bob_dk);
-    assert!(bob_result.is_ok(), "Bob should be able to decrypt his output");
+    assert!(
+        bob_result.is_ok(),
+        "Bob should be able to decrypt his output"
+    );
 
     let (bob_amount, bob_blinding) = bob_result.unwrap();
-    assert_eq!(bob_amount, output1_amount, "Bob should receive correct amount");
-    assert_eq!(bob_blinding, output1_blinding, "Blinding factors should match");
+    assert_eq!(
+        bob_amount, output1_amount,
+        "Bob should receive correct amount"
+    );
+    assert_eq!(
+        bob_blinding, output1_blinding,
+        "Blinding factors should match"
+    );
 
     // Step 7: Verify commitment opens correctly
-    assert!(conf_output_to_bob.commitment.verify_opening(bob_amount, &bob_blinding));
+    assert!(conf_output_to_bob
+        .commitment
+        .verify_opening(bob_amount, &bob_blinding));
 
     // Step 8: Alice tries to decrypt her change output
     let alice_result = conf_output_to_alice.try_decrypt(&alice_dk);
-    assert!(alice_result.is_ok(), "Alice should be able to decrypt her output");
+    assert!(
+        alice_result.is_ok(),
+        "Alice should be able to decrypt her output"
+    );
 
     let (alice_amount, alice_blinding) = alice_result.unwrap();
     assert_eq!(alice_amount, output2_amount);
@@ -95,29 +98,32 @@ fn test_full_confidential_transaction_flow() {
 
     // Step 9: Bob should NOT be able to decrypt Alice's output
     let bob_tries_alice = conf_output_to_alice.try_decrypt(&bob_dk);
-    assert!(bob_tries_alice.is_err(), "Bob should not be able to decrypt Alice's output");
+    assert!(
+        bob_tries_alice.is_err(),
+        "Bob should not be able to decrypt Alice's output"
+    );
 
     // Step 10: Alice should NOT be able to decrypt Bob's output
     let alice_tries_bob = conf_output_to_bob.try_decrypt(&alice_dk);
-    assert!(alice_tries_bob.is_err(), "Alice should not be able to decrypt Bob's output");
+    assert!(
+        alice_tries_bob.is_err(),
+        "Alice should not be able to decrypt Bob's output"
+    );
 }
 
 #[test]
 fn test_balance_proof_rejects_unbalanced_transaction() {
     // Inputs sum to 1500
-    let inputs = vec![
-        (1000u64, [1u8; 32]),
-        (500u64, [2u8; 32]),
-    ];
+    let inputs = vec![(1000u64, [1u8; 32]), (500u64, [2u8; 32])];
 
     // Outputs sum to 1400 (trying to create money out of thin air!)
-    let outputs = vec![
-        (800u64, [3u8; 32]),
-        (600u64, [4u8; 32]),
-    ];
+    let outputs = vec![(800u64, [3u8; 32]), (600u64, [4u8; 32])];
 
     let balance_witness = BalanceWitness::new(inputs, outputs);
-    assert!(balance_witness.is_none(), "Unbalanced transaction should be rejected");
+    assert!(
+        balance_witness.is_none(),
+        "Unbalanced transaction should be rejected"
+    );
 }
 
 #[test]
@@ -188,7 +194,10 @@ fn test_multi_output_confidential_transaction() {
     ];
 
     let balance_witness = BalanceWitness::new(inputs, outputs);
-    assert!(balance_witness.is_some(), "Multi-output transaction should balance");
+    assert!(
+        balance_witness.is_some(),
+        "Multi-output transaction should balance"
+    );
 
     let witness = balance_witness.unwrap();
     assert_eq!(witness.inputs.len(), 1);


### PR DESCRIPTION
## Summary
- Apply `cargo fmt` across all 9 crates (54 files)
- Fix all clippy warnings to pass CI with `RUSTFLAGS="-Dwarnings"`
- Resolve `needless_range_loop`, `collapsible_match`, and other lint issues
- Clean up informal comments for public release

## Verification
- `cargo fmt --all -- --check` passes (zero diff)
- `RUSTFLAGS="-Dwarnings" cargo clippy --all-targets` passes (zero warnings)
- `cargo test` passes (349 tests, 0 failures, 1 ignored)

## Test plan
- [ ] CI Format job passes
- [ ] CI Clippy job passes
- [ ] CI Test job passes
- [ ] CI Build Release job passes
- [ ] CI Docker Build job passes