### PR TITLE
Harden Dockerfile, add docker-publish with Trivy/cosign/SBOM

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,59 @@
+name: Docker Publish
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/disentangle-network/disentangle-node:${{ github.ref_name }}
+            ghcr.io/disentangle-network/disentangle-node:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ghcr.io/disentangle-network/disentangle-node:${{ github.ref_name }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Sign image
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          cosign sign --yes ghcr.io/disentangle-network/disentangle-node:${{ github.ref_name }}
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ghcr.io/disentangle-network/disentangle-node:${{ github.ref_name }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+      - name: Attach SBOM to image
+        run: |
+          cosign attach sbom --sbom sbom.spdx.json ghcr.io/disentangle-network/disentangle-node:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,17 @@ RUN cargo build --release --bin disentangle-node
 # Runtime stage
 FROM debian:bookworm-slim
 
-# Install runtime dependencies (ca-certificates for TLS, curl for healthchecks)
 RUN apt-get update && \
     apt-get install -y ca-certificates curl && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd -r disentangle && \
+    useradd -r -g disentangle -u 1000 -d /data -m disentangle
 
-# Copy the compiled binary from builder stage
 COPY --from=builder /app/target/release/disentangle-node /usr/local/bin/
 
-# Expose P2P and RPC ports (defaults 9000 and 8000)
+USER 1000
+WORKDIR /data
+
 EXPOSE 9000 8000
 
 ENTRYPOINT ["disentangle-node"]


### PR DESCRIPTION
## Summary
- Add dedicated non-root user (UID 1000) to Dockerfile runtime stage, matching Helm chart `runAsUser: 1000`
- Create `/data` home directory owned by the runtime user for state persistence
- Add `docker-publish.yml` workflow triggered on `v*` tags with full supply chain security:
  - Trivy vulnerability scanning (CRITICAL/HIGH severity, SARIF upload to GitHub Security tab)
  - Cosign keyless image signing via Sigstore OIDC
  - SBOM generation (SPDX-JSON) and attachment to container image

## Test plan
- [ ] Verify Dockerfile builds successfully (`docker build .`)
- [ ] Verify container runs as UID 1000 (`docker run --rm <image> id`)
- [ ] Verify `/data` directory exists and is writable by UID 1000
- [ ] Confirm workflow YAML is valid (GitHub Actions syntax check on push)
- [ ] After merge: tag `v0.3.0`, verify workflow triggers and image appears on GHCR