### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    allow:
+      - dependency-type: "direct"
+      - dependency-type: "indirect"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    allow:
+      - dependency-type: "all"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with Cargo and GitHub Actions ecosystem monitoring
- Weekly schedule on Tuesdays, max 10 open PRs, auto-labeled "dependencies"
- Cargo: allows both direct and indirect dependency updates
- GitHub Actions: allows all update types including major versions