### PR TITLE
feat: docker-compose 3-node testnet + /tips RPC endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cargo test
 docker compose up
 ```
 
-This starts a five-node local testnet with pre-configured peer discovery.
+This starts a three-node local testnet with pre-configured peer discovery.
 
 ### Run a Single Node
 

--- a/disentangle-p2p/src/bin/node.rs
+++ b/disentangle-p2p/src/bin/node.rs
@@ -149,6 +149,14 @@ async fn status_handler(State(state): State<SharedState>) -> Json<StatusResponse
     })
 }
 
+/// Returns full 32-byte hex-encoded tip hashes suitable for use as parent
+/// references in transaction submission.
+async fn tips_handler(State(state): State<SharedState>) -> Json<Vec<String>> {
+    let sync = state.sync.lock().await;
+    let tips: Vec<String> = sync.tips().iter().map(hex::encode).collect();
+    Json(tips)
+}
+
 async fn graph_handler(State(state): State<SharedState>) -> Json<GraphResponse> {
     let sync = state.sync.lock().await;
     let dag = sync.dag();
@@ -578,6 +586,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let app = Router::new()
         .route("/status", get(status_handler))
+        .route("/tips", get(tips_handler))
         .route("/graph", get(graph_handler))
         .route("/transaction", post(submit_tx_handler))
         .route("/debug/trigger-conflict", post(trigger_conflict_handler))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,31 +1,51 @@
 services:
-  # Genesis/bootstrap node
-  node1:
-    build: .
-    container_name: disentangle-node1
+  # Bootstrap node (genesis creator)
+  node-0:
+    image: ghcr.io/disentangle-network/disentangle-node:v0.4.0
+    container_name: disentangle-node-0
     command: ["9000", "8000"]
     ports:
-      - "8001:8000"  # RPC port (HTTP)
-      - "9001:9000"  # P2P port
+      - "8000:8000"  # RPC
+      - "9000:9000"  # P2P
     networks:
       - disentangle
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/status"]
       interval: 10s
       timeout: 5s
-      retries: 3
-      start_period: 10s
+      retries: 5
+      start_period: 15s
+
+  # Follower node 1
+  node-1:
+    image: ghcr.io/disentangle-network/disentangle-node:v0.4.0
+    container_name: disentangle-node-1
+    command: ["9000", "8000", "/dns4/node-0/tcp/9000"]
+    ports:
+      - "8001:8000"  # RPC
+      - "9001:9000"  # P2P
+    depends_on:
+      node-0:
+        condition: service_healthy
+    networks:
+      - disentangle
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/status"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
 
   # Follower node 2
-  node2:
-    build: .
-    container_name: disentangle-node2
-    command: ["9000", "8000", "/dns4/node1/tcp/9000"]
+  node-2:
+    image: ghcr.io/disentangle-network/disentangle-node:v0.4.0
+    container_name: disentangle-node-2
+    command: ["9000", "8000", "/dns4/node-0/tcp/9000"]
     ports:
-      - "8002:8000"
-      - "9002:9000"
+      - "8002:8000"  # RPC
+      - "9002:9000"  # P2P
     depends_on:
-      node1:
+      node-0:
         condition: service_healthy
     networks:
       - disentangle
@@ -33,68 +53,8 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8000/status"]
       interval: 10s
       timeout: 5s
-      retries: 3
-      start_period: 10s
-
-  # Follower node 3
-  node3:
-    build: .
-    container_name: disentangle-node3
-    command: ["9000", "8000", "/dns4/node1/tcp/9000"]
-    ports:
-      - "8003:8000"
-      - "9003:9000"
-    depends_on:
-      node1:
-        condition: service_healthy
-    networks:
-      - disentangle
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/status"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-      start_period: 10s
-
-  # Follower node 4
-  node4:
-    build: .
-    container_name: disentangle-node4
-    command: ["9000", "8000", "/dns4/node1/tcp/9000"]
-    ports:
-      - "8004:8000"
-      - "9004:9000"
-    depends_on:
-      node1:
-        condition: service_healthy
-    networks:
-      - disentangle
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/status"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-      start_period: 10s
-
-  # Follower node 5
-  node5:
-    build: .
-    container_name: disentangle-node5
-    command: ["9000", "8000", "/dns4/node1/tcp/9000"]
-    ports:
-      - "8005:8000"
-      - "9005:9000"
-    depends_on:
-      node1:
-        condition: service_healthy
-    networks:
-      - disentangle
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/status"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-      start_period: 10s
+      retries: 5
+      start_period: 15s
 
 networks:
   disentangle:


### PR DESCRIPTION
## Summary
- Slim docker-compose.yml from 5 nodes to 3, using published `ghcr.io/disentangle-network/disentangle-node:v0.4.0` image instead of local builds
- Add `/tips` GET endpoint returning hex-encoded DAG tip hashes for transaction parent references
- Update README to reflect 3-node testnet