### PR TITLE
chore: bump workspace version to 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Disentangle Network Contributors"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Aligns Cargo.toml workspace version with git tag convention (was `0.3.0`, tags are `v0.4.x`)
- Prepares for v0.4.1 tag after merge

## Test plan

- [x] `cargo check` passes (all 9 crates compile at 0.4.1)