### PR TITLE
fix: resolve arm64 Docker cross-compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,20 @@ ARG TARGETARCH
 
 WORKDIR /app
 
-# Install cross-compilation toolchains if needed
+# Copy source first so rust-toolchain.toml is available before rustup/cargo
+COPY . .
+
+# Install cross-compilation toolchain and Rust target.
+# This must run AFTER COPY so that rust-toolchain.toml is in place —
+# otherwise rustup target add installs the stdlib for the Docker image's
+# default toolchain, but cargo later switches to the toolchain specified
+# in rust-toolchain.toml and the target stdlib is missing (error[E0463]).
 RUN case "$TARGETARCH" in \
         arm64) apt-get update && apt-get install -y gcc-aarch64-linux-gnu && \
+               rm -rf /var/lib/apt/lists/* && \
                rustup target add aarch64-unknown-linux-gnu ;; \
         amd64) rustup target add x86_64-unknown-linux-gnu ;; \
     esac
-
-# Copy the entire workspace
-COPY . .
 
 # Build the release binary for the target architecture
 RUN case "$TARGETARCH" in \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "stable"
 components = ["rustfmt", "clippy"]
+targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]


### PR DESCRIPTION
## Summary
- Reorders Dockerfile so `COPY . .` runs before `rustup target add`, ensuring `rust-toolchain.toml` is in place when the aarch64 target stdlib is installed
- Adds `targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]` to `rust-toolchain.toml` so both targets are automatically installed on any toolchain switch

## Root cause
The Docker image uses `rust:1.85-bookworm` but the repo's `rust-toolchain.toml` specifies `channel = "stable"` (currently newer than 1.85). The old Dockerfile ran `rustup target add aarch64-unknown-linux-gnu` before `COPY`, so the target was installed for the 1.85 toolchain. When `cargo build` later ran after `COPY`, it detected `rust-toolchain.toml`, switched to the current stable toolchain, and could not find `core` for `aarch64-unknown-linux-gnu` -- hence `error[E0463]`.

## Test plan
- [ ] Tag a pre-release (or re-run the Docker Publish workflow) and verify both amd64 and arm64 images build successfully
- [ ] Verify `docker manifest inspect` shows both platforms in the manifest list