### PR TITLE
Fix RPC transaction submission path bugs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target/
+.git/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "disentangle-cli"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "dirs",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "disentangle-consensus"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "disentangle-crypto",
  "disentangle-dag",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "disentangle-crypto"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "hex",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "disentangle-dag"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "disentangle-crypto",
  "disentangle-simhash",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "disentangle-identity"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "bincode",
  "disentangle-crypto",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "disentangle-node"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "async-stream",
  "axum",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "disentangle-p2p"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "axum",
  "bincode",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "disentangle-simhash"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "disentangle-crypto",
  "serde",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "disentangle-zkp"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "bincode",
  "criterion",

--- a/disentangle-p2p/src/bin/node.rs
+++ b/disentangle-p2p/src/bin/node.rs
@@ -8,7 +8,7 @@ use disentangle_crypto::{
     signature::{generate_keypair as generate_dilithium_keypair, sign as dilithium_sign},
     types::{Epoch, Nullifier},
 };
-use disentangle_dag::{NodeId, Transaction, SCALE};
+use disentangle_dag::{NodeId, Transaction, MAX_PARENTS, MIN_PARENTS, SCALE};
 use disentangle_node::{identity_rpc, identity_state::IdentityStateManager, HelloWorldPoW};
 use disentangle_p2p::{
     behaviour::{DisentangleRequest, DisentangleResponse},
@@ -231,6 +231,30 @@ async fn submit_tx_handler(
         }
     }
 
+    // Validate parent count before doing any work
+    if parents.len() < MIN_PARENTS {
+        return Json(TxResponse {
+            success: false,
+            tx_id: None,
+            error: Some(format!(
+                "Too few parents: {} provided, minimum is {}",
+                parents.len(),
+                MIN_PARENTS
+            )),
+        });
+    }
+    if parents.len() > MAX_PARENTS {
+        return Json(TxResponse {
+            success: false,
+            tx_id: None,
+            error: Some(format!(
+                "Too many parents: {} provided, maximum is {}",
+                parents.len(),
+                MAX_PARENTS
+            )),
+        });
+    }
+
     let mut height = state.max_depth.lock().await;
     *height += 1;
     let block = *height;
@@ -275,23 +299,39 @@ async fn submit_tx_handler(
     let nonce = pow.mine(&tx_header);
     let wire_tx = WireTransaction::new(tx, nonce);
     let tx_id_hex = hex::encode(&tx_id[..8]);
-    if state
-        .cmd_tx
-        .send(NodeCommand::BroadcastTx(wire_tx))
-        .await
-        .is_err()
-    {
-        return Json(TxResponse {
-            success: false,
-            tx_id: None,
-            error: Some("Failed to send to P2P layer".into()),
-        });
+
+    // Insert locally first, then broadcast to peers
+    let mut sync = state.sync.lock().await;
+    match sync.receive_transaction(wire_tx.clone()) {
+        SyncResult::Inserted => {
+            drop(sync);
+            if state
+                .cmd_tx
+                .send(NodeCommand::BroadcastTx(wire_tx))
+                .await
+                .is_err()
+            {
+                return Json(TxResponse {
+                    success: false,
+                    tx_id: None,
+                    error: Some("Inserted locally but failed to broadcast to peers".into()),
+                });
+            }
+            Json(TxResponse {
+                success: true,
+                tx_id: Some(tx_id_hex),
+                error: None,
+            })
+        }
+        other => {
+            drop(sync);
+            Json(TxResponse {
+                success: false,
+                tx_id: None,
+                error: Some(format!("DAG rejected transaction: {:?}", other)),
+            })
+        }
     }
-    Json(TxResponse {
-        success: true,
-        tx_id: Some(tx_id_hex),
-        error: None,
-    })
 }
 
 async fn trigger_conflict_handler(State(state): State<SharedState>) -> Json<ConflictResponse> {

--- a/disentangle-p2p/src/sync.rs
+++ b/disentangle-p2p/src/sync.rs
@@ -121,10 +121,7 @@ impl SyncState {
 
     fn insert_and_propagate(&mut self, wire_tx: WireTransaction) {
         let tx_id = wire_tx.tx.id;
-        for parent in &wire_tx.tx.parents {
-            self.tips.remove(parent);
-        }
-        self.tips.insert(tx_id);
+        let parents = wire_tx.tx.parents.clone();
         // Genesis transactions (no parents) bypass parent validation
         if wire_tx.tx.parents.is_empty() {
             self.dag.insert_genesis(wire_tx.tx);
@@ -132,6 +129,11 @@ impl SyncState {
             warn!("Failed to insert tx {:?}: {}", &tx_id[..4], e);
             return;
         }
+        // Update tips only after successful DAG insertion
+        for parent in &parents {
+            self.tips.remove(parent);
+        }
+        self.tips.insert(tx_id);
         self.request_counts.remove(&tx_id);
         info!("Inserted tx {:?}", &tx_id[..4]);
         if let Some(waiters) = self.waiting_for.remove(&tx_id) {
@@ -147,14 +149,16 @@ impl SyncState {
             while let Some(ready_id) = ready.pop_front() {
                 if let Some(pending) = self.pending.remove(&ready_id) {
                     let child_tx_id = pending.wire_tx.tx.id;
-                    for parent in &pending.wire_tx.tx.parents {
-                        self.tips.remove(parent);
-                    }
-                    self.tips.insert(child_tx_id);
+                    let child_parents = pending.wire_tx.tx.parents.clone();
                     if let Err(e) = self.dag.insert(pending.wire_tx.tx) {
                         warn!("Failed to insert pending tx {:?}: {}", &child_tx_id[..4], e);
                         continue;
                     }
+                    // Update tips only after successful DAG insertion
+                    for parent in &child_parents {
+                        self.tips.remove(parent);
+                    }
+                    self.tips.insert(child_tx_id);
                     self.request_counts.remove(&child_tx_id);
                     info!("Inserted pending tx {:?}", &child_tx_id[..4]);
                     if let Some(child_waiters) = self.waiting_for.remove(&child_tx_id) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # Bootstrap node (genesis creator)
   node-0:
-    image: ghcr.io/disentangle-network/disentangle-node:v0.4.0
+    image: ghcr.io/disentangle-network/disentangle-node:v0.4.1
     container_name: disentangle-node-0
     command: ["9000", "8000"]
     ports:
@@ -18,7 +18,7 @@ services:
 
   # Follower node 1
   node-1:
-    image: ghcr.io/disentangle-network/disentangle-node:v0.4.0
+    image: ghcr.io/disentangle-network/disentangle-node:v0.4.1
     container_name: disentangle-node-1
     command: ["9000", "8000", "/dns4/node-0/tcp/9000"]
     ports:
@@ -38,7 +38,7 @@ services:
 
   # Follower node 2
   node-2:
-    image: ghcr.io/disentangle-network/disentangle-node:v0.4.0
+    image: ghcr.io/disentangle-network/disentangle-node:v0.4.1
     container_name: disentangle-node-2
     command: ["9000", "8000", "/dns4/node-0/tcp/9000"]
     ports:


### PR DESCRIPTION
## Summary

- **No local insert**: submit handler now calls `sync.receive_transaction()` before broadcasting, matching auto-mine and identity payload patterns
- **Tip consistency**: `insert_and_propagate` updates tips only after successful `dag.insert()`, preventing stale state on validation failure
- **Parent count validation**: early `MIN_PARENTS`/`MAX_PARENTS` check before PoW computation returns clear errors to callers

Also adds `.dockerignore` (prevents 16GB `target/` copy into build context) and syncs `Cargo.lock` versions + `docker-compose.yml` image tag to v0.4.1.

## Test plan

- [x] `cargo test --workspace` -- 483 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` -- clean
- [x] Docker 3-node testnet: tx submitted via RPC appears in originating node DAG (size 3 -> 4)
- [x] Docker 3-node testnet: tx propagates to all followers (all nodes at DAG size 4)
- [x] Docker 3-node testnet: single-parent submit returns `"Too few parents: 1 provided, minimum is 2"`

Closes #21