### PR TITLE
feat(identity): implement DID document update with proof verification

### DIFF
--- a/disentangle-dag/src/lib.rs
+++ b/disentangle-dag/src/lib.rs
@@ -100,6 +100,8 @@ pub enum TransactionPayload {
     RegisterIdentity { did_document: Vec<u8> },
     /// Deactivate a DID.
     DeactivateIdentity { did: String },
+    /// Update a DID document. updates is bincode-serialized Vec<DIDUpdateOp>.
+    UpdateIdentity { did: String, updates: Vec<u8> },
 
     // -- Social graph --
     /// Create an introduction between two DIDs.

--- a/disentangle-node/src/identity_rpc.rs
+++ b/disentangle-node/src/identity_rpc.rs
@@ -13,8 +13,8 @@ use axum::{
 };
 use disentangle_crypto::signature::SigningKey;
 use disentangle_identity::{
-    AgentType, CapabilitySubject, Constraint, OracleQuery, ProposalType, RegionSelector,
-    RevocationScope, VoteChoice,
+    AgentType, CapabilitySubject, Constraint, DIDUpdateOp, OracleQuery, ProposalType,
+    RegionSelector, RevocationScope, ServiceEndpoint, VoteChoice,
 };
 use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
@@ -190,6 +190,125 @@ pub async fn identity_deactivate_handler(
     })?;
 
     Ok(Json(SuccessResponse { success: true }))
+}
+
+// Update endpoint
+
+#[derive(Deserialize)]
+pub struct UpdateServiceEndpoint {
+    pub id: String,
+    pub service_type: String,
+    pub endpoint: String,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateIdentityRequest {
+    #[serde(default)]
+    pub add_service_endpoints: Vec<UpdateServiceEndpoint>,
+    #[serde(default)]
+    pub remove_service_ids: Vec<String>,
+    #[serde(default)]
+    pub new_agent_type: Option<String>,
+    pub proof_hex: String,
+}
+
+#[derive(Serialize)]
+pub struct UpdateIdentityResponse {
+    pub document: serde_json::Value,
+}
+
+pub async fn identity_update_handler(
+    State(state): State<IdentityState>,
+    Path(did): Path<String>,
+    Json(req): Json<UpdateIdentityRequest>,
+) -> Result<Json<UpdateIdentityResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let mut mgr = state.lock().await;
+
+    let proof = hex::decode(&req.proof_hex).map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "Invalid proof hex encoding".to_string(),
+                coherence_score: None,
+            }),
+        )
+    })?;
+
+    // Build the update operations from the request
+    let mut ops: Vec<DIDUpdateOp> = Vec::new();
+
+    for ep in &req.add_service_endpoints {
+        ops.push(DIDUpdateOp::AddService(ServiceEndpoint {
+            id: ep.id.clone(),
+            service_type: ep.service_type.clone(),
+            endpoint: ep.endpoint.clone(),
+        }));
+    }
+
+    for service_id in &req.remove_service_ids {
+        ops.push(DIDUpdateOp::RemoveService(service_id.clone()));
+    }
+
+    if let Some(ref agent_type_str) = req.new_agent_type {
+        let agent_type = match agent_type_str.to_lowercase().as_str() {
+            "human" => AgentType::Human,
+            "agi" => AgentType::AGI {
+                runtime_attestation: None,
+            },
+            _ => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorResponse {
+                        error: format!(
+                            "Invalid agent_type: must be 'human' or 'agi', got '{}'",
+                            agent_type_str
+                        ),
+                        coherence_score: None,
+                    }),
+                ))
+            }
+        };
+        ops.push(DIDUpdateOp::UpdateAgentType(agent_type));
+    }
+
+    if ops.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "No update operations provided".to_string(),
+                coherence_score: None,
+            }),
+        ));
+    }
+
+    let updated_doc = mgr.update_did(&did, ops, &proof).map_err(|e| {
+        let status = match &e {
+            disentangle_identity::IdentityError::DIDNotFound(_) => StatusCode::NOT_FOUND,
+            disentangle_identity::IdentityError::SignatureVerificationFailed => {
+                StatusCode::FORBIDDEN
+            }
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        (
+            status,
+            Json(ErrorResponse {
+                error: format!("Failed to update DID: {}", e),
+                coherence_score: None,
+            }),
+        )
+    })?;
+
+    let doc_json = serde_json::to_value(&updated_doc).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: format!("Failed to serialize document: {}", e),
+                coherence_score: None,
+            }),
+        )
+    })?;
+
+    Ok(Json(UpdateIdentityResponse { document: doc_json }))
 }
 
 // Capability endpoints

--- a/disentangle-node/src/identity_state.rs
+++ b/disentangle-node/src/identity_state.rs
@@ -9,7 +9,7 @@ use disentangle_dag::{NodeId, TransactionPayload};
 use disentangle_identity::{
     evaluate_proposal, AgentScore, AgentType, AgreementStatus, AgreementTerms, Capability,
     CapabilityId, CapabilitySubject, CoherenceGradientMap, CoherenceProfile, CommonsPool,
-    Constraint, ConstraintContext, CurvatureDerivative, CurvatureHistory, DIDDocument,
+    Constraint, ConstraintContext, CurvatureDerivative, CurvatureHistory, DIDDocument, DIDUpdateOp,
     DelegationRecord, DistributionRoot, ExcitabilityProfile, GovernanceProposal, GovernanceVote,
     IdentityError, IdentityGraph, IntentCoherenceSnapshot, IntentParticipant, IntentStatus,
     IntroductionContext, IntroductionTransaction, JoinCommitment, OracleQuery, PetnameDB, Proposal,
@@ -196,6 +196,93 @@ impl IdentityStateManager {
 
         self.did_registry.remove(did);
         Ok(())
+    }
+
+    /// Update a DID document (requires proof of ownership via signature verification).
+    ///
+    /// The `proof` must be a valid ML-DSA-87 signature over the domain-separated
+    /// update payload `b"DID_UPDATE_V1" || serialized_updates`, signed by the
+    /// verifying key stored alongside the DID in the registry.
+    ///
+    /// Supported operations (via `DIDUpdateOp`):
+    /// - `AddService` / `RemoveService`: modify service endpoints
+    /// - `UpdateAgentType`: change the agent type
+    /// - `AddVerificationMethod` / `RemoveVerificationMethod`: modify verification methods
+    ///   (note: key rotation is a separate, more privileged operation)
+    pub fn update_did(
+        &mut self,
+        did: &str,
+        updates: Vec<DIDUpdateOp>,
+        proof: &[u8],
+    ) -> Result<DIDDocument, IdentityError> {
+        let (_, pk) = self
+            .did_registry
+            .get(did)
+            .ok_or_else(|| IdentityError::DIDNotFound(did.to_string()))?;
+        let pk = pk.clone();
+
+        // Build the expected update payload (same domain separation as DIDUpdate transaction)
+        let mut message = Vec::new();
+        message.extend_from_slice(b"DID_UPDATE_V1");
+        if let Ok(updates_bytes) = bincode::serialize(&updates) {
+            message.extend_from_slice(&updates_bytes);
+        }
+
+        // Parse the proof bytes into a Signature and verify against the stored key
+        let signature = disentangle_crypto::signature::Signature::from_bytes(proof)
+            .map_err(|_| IdentityError::SignatureVerificationFailed)?;
+
+        disentangle_crypto::signature::verify(&pk, &message, &signature)
+            .map_err(|_| IdentityError::SignatureVerificationFailed)?;
+
+        // Apply updates to the stored DIDDocument
+        let (doc, _) = self
+            .did_registry
+            .get_mut(did)
+            .ok_or_else(|| IdentityError::DIDNotFound(did.to_string()))?;
+
+        for op in &updates {
+            match op {
+                DIDUpdateOp::AddService(endpoint) => {
+                    // Idempotent: only add if not already present
+                    if !doc.service.iter().any(|s| s.id == endpoint.id) {
+                        doc.service.push(endpoint.clone());
+                    }
+                }
+                DIDUpdateOp::RemoveService(service_id) => {
+                    doc.service.retain(|s| s.id != *service_id);
+                }
+                DIDUpdateOp::UpdateAgentType(agent_type) => {
+                    doc.agent_type = agent_type.clone();
+                }
+                DIDUpdateOp::AddVerificationMethod(method) => {
+                    if !doc.verification_methods.iter().any(|m| m.id == method.id) {
+                        doc.verification_methods.push(method.clone());
+                    }
+                }
+                DIDUpdateOp::RemoveVerificationMethod(method_id) => {
+                    doc.verification_methods.retain(|m| m.id != *method_id);
+                }
+            }
+        }
+
+        // Update the document's timestamp
+        doc.updated_depth = self.current_depth;
+
+        let updated_doc = doc.clone();
+
+        // Queue payload for federation broadcast
+        if let Ok(updates_bytes) = bincode::serialize(&updates) {
+            self.pending_payloads.push(PendingPayload {
+                payload: TransactionPayload::UpdateIdentity {
+                    did: did.to_string(),
+                    updates: updates_bytes,
+                },
+                signer_pk: pk,
+            });
+        }
+
+        Ok(updated_doc)
     }
 
     // Capability Operations
@@ -1658,6 +1745,45 @@ impl IdentityStateManager {
             TransactionPayload::DeactivateIdentity { did } => {
                 // Idempotent -- silently succeed if not found
                 self.did_registry.remove(did);
+                Ok(())
+            }
+
+            TransactionPayload::UpdateIdentity { did, updates } => {
+                // Skip if DID not found (may not have propagated yet)
+                let entry = match self.did_registry.get_mut(did) {
+                    Some(e) => e,
+                    None => return Ok(()),
+                };
+
+                let ops: Vec<DIDUpdateOp> = bincode::deserialize(updates).map_err(|e| {
+                    IdentityError::InvalidDID(format!("Failed to deserialize DIDUpdateOps: {}", e))
+                })?;
+
+                let doc = &mut entry.0;
+                for op in &ops {
+                    match op {
+                        DIDUpdateOp::AddService(endpoint) => {
+                            if !doc.service.iter().any(|s| s.id == endpoint.id) {
+                                doc.service.push(endpoint.clone());
+                            }
+                        }
+                        DIDUpdateOp::RemoveService(service_id) => {
+                            doc.service.retain(|s| s.id != *service_id);
+                        }
+                        DIDUpdateOp::UpdateAgentType(agent_type) => {
+                            doc.agent_type = agent_type.clone();
+                        }
+                        DIDUpdateOp::AddVerificationMethod(method) => {
+                            if !doc.verification_methods.iter().any(|m| m.id == method.id) {
+                                doc.verification_methods.push(method.clone());
+                            }
+                        }
+                        DIDUpdateOp::RemoveVerificationMethod(method_id) => {
+                            doc.verification_methods.retain(|m| m.id != *method_id);
+                        }
+                    }
+                }
+                doc.updated_depth = depth;
                 Ok(())
             }
 
@@ -3405,5 +3531,236 @@ mod tests {
 
         // DID should still be registered
         assert!(manager.get_did_document(&did.0).is_some());
+    }
+
+    // ── DID update proof verification tests ──
+
+    /// Helper to build the update proof message (same domain separation as update_did)
+    fn build_update_proof_message(updates: &[DIDUpdateOp]) -> Vec<u8> {
+        let mut message = Vec::new();
+        message.extend_from_slice(b"DID_UPDATE_V1");
+        if let Ok(updates_bytes) = bincode::serialize(updates) {
+            message.extend_from_slice(&updates_bytes);
+        }
+        message
+    }
+
+    #[test]
+    fn test_update_did_add_service_endpoints() {
+        let mut manager = IdentityStateManager::new();
+        let (did, _doc, sk) = manager.register_did(AgentType::Human).unwrap();
+
+        // Verify no service endpoints initially
+        let doc = manager.get_did_document(&did.0).unwrap();
+        assert!(doc.service.is_empty());
+
+        // Build update ops
+        let updates = vec![
+            DIDUpdateOp::AddService(disentangle_identity::ServiceEndpoint {
+                id: "svc-1".to_string(),
+                service_type: "MessagingService".to_string(),
+                endpoint: "https://example.com/msg".to_string(),
+            }),
+            DIDUpdateOp::AddService(disentangle_identity::ServiceEndpoint {
+                id: "svc-2".to_string(),
+                service_type: "StorageService".to_string(),
+                endpoint: "https://example.com/storage".to_string(),
+            }),
+        ];
+
+        let message = build_update_proof_message(&updates);
+        let proof = disentangle_crypto::signature::sign(&sk, &message);
+
+        let result = manager.update_did(&did.0, updates, proof.to_bytes());
+        assert!(result.is_ok());
+
+        let updated_doc = result.unwrap();
+        assert_eq!(updated_doc.service.len(), 2);
+        assert_eq!(updated_doc.service[0].id, "svc-1");
+        assert_eq!(updated_doc.service[1].id, "svc-2");
+
+        // Verify change persists in registry
+        let stored_doc = manager.get_did_document(&did.0).unwrap();
+        assert_eq!(stored_doc.service.len(), 2);
+    }
+
+    #[test]
+    fn test_update_did_remove_service_endpoint() {
+        let mut manager = IdentityStateManager::new();
+        let (did, _doc, sk) = manager.register_did(AgentType::Human).unwrap();
+
+        // First add a service
+        let add_ops = vec![DIDUpdateOp::AddService(
+            disentangle_identity::ServiceEndpoint {
+                id: "svc-remove-me".to_string(),
+                service_type: "TempService".to_string(),
+                endpoint: "https://example.com/temp".to_string(),
+            },
+        )];
+        let msg = build_update_proof_message(&add_ops);
+        let proof = disentangle_crypto::signature::sign(&sk, &msg);
+        manager
+            .update_did(&did.0, add_ops, proof.to_bytes())
+            .unwrap();
+        assert_eq!(manager.get_did_document(&did.0).unwrap().service.len(), 1);
+
+        // Now remove it
+        let remove_ops = vec![DIDUpdateOp::RemoveService("svc-remove-me".to_string())];
+        let msg = build_update_proof_message(&remove_ops);
+        let proof = disentangle_crypto::signature::sign(&sk, &msg);
+        let result = manager.update_did(&did.0, remove_ops, proof.to_bytes());
+        assert!(result.is_ok());
+
+        let updated_doc = result.unwrap();
+        assert!(updated_doc.service.is_empty());
+    }
+
+    #[test]
+    fn test_update_did_change_agent_type() {
+        let mut manager = IdentityStateManager::new();
+        let (did, _doc, sk) = manager.register_did(AgentType::Human).unwrap();
+
+        // Verify initial agent type is Human
+        let doc = manager.get_did_document(&did.0).unwrap();
+        assert!(matches!(doc.agent_type, AgentType::Human));
+
+        // Update to AGI
+        let updates = vec![DIDUpdateOp::UpdateAgentType(AgentType::AGI {
+            runtime_attestation: None,
+        })];
+        let message = build_update_proof_message(&updates);
+        let proof = disentangle_crypto::signature::sign(&sk, &message);
+
+        let result = manager.update_did(&did.0, updates, proof.to_bytes());
+        assert!(result.is_ok());
+
+        let updated_doc = result.unwrap();
+        assert!(matches!(updated_doc.agent_type, AgentType::AGI { .. }));
+
+        // Verify persistence
+        let stored_doc = manager.get_did_document(&did.0).unwrap();
+        assert!(matches!(stored_doc.agent_type, AgentType::AGI { .. }));
+    }
+
+    #[test]
+    fn test_update_did_invalid_proof_rejected() {
+        let mut manager = IdentityStateManager::new();
+        let (did, _doc, _sk) = manager.register_did(AgentType::Human).unwrap();
+
+        let updates = vec![DIDUpdateOp::AddService(
+            disentangle_identity::ServiceEndpoint {
+                id: "svc-bad".to_string(),
+                service_type: "BadService".to_string(),
+                endpoint: "https://evil.com".to_string(),
+            },
+        )];
+
+        // Attempt with garbage proof bytes (too short for valid signature)
+        let result = manager.update_did(&did.0, updates.clone(), b"deadbeef");
+        assert!(result.is_err());
+
+        // DID should be unchanged
+        let doc = manager.get_did_document(&did.0).unwrap();
+        assert!(doc.service.is_empty());
+    }
+
+    #[test]
+    fn test_update_did_wrong_key_rejected() {
+        let mut manager = IdentityStateManager::new();
+        let (did, _doc, _sk) = manager.register_did(AgentType::Human).unwrap();
+
+        let updates = vec![DIDUpdateOp::AddService(
+            disentangle_identity::ServiceEndpoint {
+                id: "svc-wrong".to_string(),
+                service_type: "WrongService".to_string(),
+                endpoint: "https://wrong.com".to_string(),
+            },
+        )];
+
+        // Sign with a different key
+        let (wrong_sk, _) = disentangle_crypto::signature::generate_keypair();
+        let message = build_update_proof_message(&updates);
+        let bad_proof = disentangle_crypto::signature::sign(&wrong_sk, &message);
+
+        let result = manager.update_did(&did.0, updates, bad_proof.to_bytes());
+        assert!(result.is_err());
+
+        // DID should be unchanged
+        let doc = manager.get_did_document(&did.0).unwrap();
+        assert!(doc.service.is_empty());
+    }
+
+    #[test]
+    fn test_update_did_nonexistent_rejected() {
+        let mut manager = IdentityStateManager::new();
+
+        let updates = vec![DIDUpdateOp::AddService(
+            disentangle_identity::ServiceEndpoint {
+                id: "svc-phantom".to_string(),
+                service_type: "PhantomService".to_string(),
+                endpoint: "https://phantom.com".to_string(),
+            },
+        )];
+
+        // Attempt update on a DID that was never registered
+        let result = manager.update_did("did:disentangle:nonexistent", updates, b"irrelevant");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_update_did_idempotent_add_service() {
+        let mut manager = IdentityStateManager::new();
+        let (did, _doc, sk) = manager.register_did(AgentType::Human).unwrap();
+
+        let endpoint = disentangle_identity::ServiceEndpoint {
+            id: "svc-idem".to_string(),
+            service_type: "IdempotentService".to_string(),
+            endpoint: "https://idem.com".to_string(),
+        };
+
+        // Add the same service twice in one update
+        let updates = vec![
+            DIDUpdateOp::AddService(endpoint.clone()),
+            DIDUpdateOp::AddService(endpoint),
+        ];
+        let message = build_update_proof_message(&updates);
+        let proof = disentangle_crypto::signature::sign(&sk, &message);
+
+        let result = manager.update_did(&did.0, updates, proof.to_bytes());
+        assert!(result.is_ok());
+
+        // Should only have one service (idempotent)
+        let doc = result.unwrap();
+        assert_eq!(doc.service.len(), 1);
+    }
+
+    #[test]
+    fn test_update_did_queues_payload() {
+        let mut manager = IdentityStateManager::new();
+        let (did, _doc, sk) = manager.register_did(AgentType::Human).unwrap();
+
+        // Drain the registration payload
+        manager.drain_payloads();
+
+        let updates = vec![DIDUpdateOp::AddService(
+            disentangle_identity::ServiceEndpoint {
+                id: "svc-fed".to_string(),
+                service_type: "FederationService".to_string(),
+                endpoint: "https://fed.com".to_string(),
+            },
+        )];
+        let message = build_update_proof_message(&updates);
+        let proof = disentangle_crypto::signature::sign(&sk, &message);
+
+        manager
+            .update_did(&did.0, updates, proof.to_bytes())
+            .unwrap();
+
+        let payloads = manager.drain_payloads();
+        assert_eq!(payloads.len(), 1);
+        assert!(matches!(
+            &payloads[0].payload,
+            TransactionPayload::UpdateIdentity { did: d, .. } if d == &did.0
+        ));
     }
 }

--- a/disentangle-node/tests/identity_rpc_tests.rs
+++ b/disentangle-node/tests/identity_rpc_tests.rs
@@ -32,6 +32,10 @@ fn create_test_router() -> Router {
             "/identity/:did",
             axum::routing::delete(identity_deactivate_handler),
         )
+        .route(
+            "/identity/:did",
+            axum::routing::put(identity_update_handler),
+        )
         // Capability endpoints
         .route(
             "/capability/create",
@@ -129,6 +133,25 @@ async fn get_request(router: &Router, path: &str) -> (StatusCode, Value) {
 async fn delete_request(router: &Router, path: &str, body: Value) -> (StatusCode, Value) {
     let request = Request::builder()
         .method("DELETE")
+        .uri(path)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(&body).unwrap()))
+        .unwrap();
+
+    let response = router.clone().oneshot(request).await.unwrap();
+    let status = response.status();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body_json: Value = serde_json::from_slice(&body_bytes).unwrap_or(json!({}));
+
+    (status, body_json)
+}
+
+/// Helper to send a PUT request with JSON body
+async fn put_json(router: &Router, path: &str, body: Value) -> (StatusCode, Value) {
+    let request = Request::builder()
+        .method("PUT")
         .uri(path)
         .header("content-type", "application/json")
         .body(Body::from(serde_json::to_string(&body).unwrap()))
@@ -1645,4 +1668,154 @@ async fn test_combined_delegation_and_coherence_constraint() {
         "Error should indicate constraint failure, got: {}",
         response["error"]
     );
+}
+
+// ============================================================================
+// DID UPDATE ENDPOINT TESTS
+// ============================================================================
+
+#[tokio::test]
+async fn test_update_identity_add_service() {
+    let router = create_test_router();
+
+    // Register an identity
+    let body = json!({"agent_type": "human"});
+    let (_, register_response) = post_json(&router, "/identity/register", body).await;
+    let did = register_response["did"].as_str().unwrap().to_string();
+    let sk_hex = register_response["signing_key_hex"].as_str().unwrap();
+
+    // Reconstruct the signing key
+    let sk_bytes = hex::decode(sk_hex).unwrap();
+    let sk = SigningKey::from_bytes(&sk_bytes).unwrap();
+
+    // Build the update operations (must match what the handler constructs)
+    let ops = vec![disentangle_identity::DIDUpdateOp::AddService(
+        disentangle_identity::ServiceEndpoint {
+            id: "svc-rpc-1".to_string(),
+            service_type: "MessagingService".to_string(),
+            endpoint: "https://example.com/msg".to_string(),
+        },
+    )];
+
+    // Sign the update proof (same domain separation as update_did)
+    let mut message = Vec::new();
+    message.extend_from_slice(b"DID_UPDATE_V1");
+    message.extend_from_slice(&bincode::serialize(&ops).unwrap());
+    let proof = sign(&sk, &message);
+    let proof_hex = hex::encode(proof.to_bytes());
+
+    // Send the update request
+    let update_body = json!({
+        "add_service_endpoints": [{
+            "id": "svc-rpc-1",
+            "service_type": "MessagingService",
+            "endpoint": "https://example.com/msg"
+        }],
+        "proof_hex": proof_hex
+    });
+
+    let (status, response) = put_json(&router, &format!("/identity/{}", did), update_body).await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "Update should succeed. Response: {:?}",
+        response
+    );
+    assert!(response["document"].is_object());
+
+    // Verify the service endpoint was added
+    let services = &response["document"]["service"];
+    assert!(services.is_array());
+    assert_eq!(services.as_array().unwrap().len(), 1);
+    assert_eq!(services[0]["id"], "svc-rpc-1");
+    assert_eq!(services[0]["service_type"], "MessagingService");
+    assert_eq!(services[0]["endpoint"], "https://example.com/msg");
+
+    // Verify change persists via GET
+    let (get_status, get_response) = get_request(&router, &format!("/identity/{}", did)).await;
+    assert_eq!(get_status, StatusCode::OK);
+    let get_services = &get_response["document"]["service"];
+    assert_eq!(get_services.as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn test_update_identity_invalid_proof_rejected() {
+    let router = create_test_router();
+
+    // Register an identity
+    let body = json!({"agent_type": "human"});
+    let (_, register_response) = post_json(&router, "/identity/register", body).await;
+    let did = register_response["did"].as_str().unwrap().to_string();
+
+    // Send an update with an invalid proof
+    let update_body = json!({
+        "add_service_endpoints": [{
+            "id": "svc-bad",
+            "service_type": "BadService",
+            "endpoint": "https://bad.com"
+        }],
+        "proof_hex": "deadbeef"
+    });
+
+    let (status, response) = put_json(&router, &format!("/identity/{}", did), update_body).await;
+
+    // Should fail -- invalid proof
+    assert_ne!(status, StatusCode::OK);
+    assert!(response["error"].is_string());
+
+    // Verify DID is unchanged (no service endpoints added)
+    let (get_status, get_response) = get_request(&router, &format!("/identity/{}", did)).await;
+    assert_eq!(get_status, StatusCode::OK);
+    let services = &get_response["document"]["service"];
+    assert!(
+        services.as_array().unwrap().is_empty(),
+        "Service endpoints should not be modified by failed update"
+    );
+}
+
+#[tokio::test]
+async fn test_update_identity_nonexistent_did() {
+    let router = create_test_router();
+
+    let update_body = json!({
+        "add_service_endpoints": [{
+            "id": "svc-phantom",
+            "service_type": "PhantomService",
+            "endpoint": "https://phantom.com"
+        }],
+        "proof_hex": "aabb"
+    });
+
+    let (status, _) = put_json(
+        &router,
+        "/identity/did:disentangle:nonexistent",
+        update_body,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_update_identity_no_ops() {
+    let router = create_test_router();
+
+    // Register an identity
+    let body = json!({"agent_type": "human"});
+    let (_, register_response) = post_json(&router, "/identity/register", body).await;
+    let did = register_response["did"].as_str().unwrap().to_string();
+
+    // Send an update with no operations (just a proof)
+    let update_body = json!({
+        "proof_hex": "aabb"
+    });
+
+    let (status, response) = put_json(&router, &format!("/identity/{}", did), update_body).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(response["error"]
+        .as_str()
+        .unwrap()
+        .contains("No update operations"));
 }

--- a/disentangle-p2p/src/bin/node.rs
+++ b/disentangle-p2p/src/bin/node.rs
@@ -518,6 +518,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "/identity/:did",
             axum::routing::delete(identity_rpc::identity_deactivate_handler),
         )
+        .route(
+            "/identity/:did",
+            axum::routing::put(identity_rpc::identity_update_handler),
+        )
         .route("/identity", get(identity_rpc::identity_list_handler))
         // Capability endpoints
         .route(


### PR DESCRIPTION
## Summary
- Adds `PUT /identity/{did}` RPC endpoint for authenticated DID document updates
- Supports 5 update operations: AddService, RemoveService, UpdateAgentType, AddVerificationMethod, RemoveVerificationMethod
- ML-DSA-87 signature verification over domain-separated payload (`DID_UPDATE_V1 || serialized_updates`)
- Idempotent operation semantics (adding existing service is no-op)
- Federation broadcast via UpdateIdentity transaction payload
- Proper HTTP status codes: 400 (bad input), 403 (bad proof), 404 (not found)

## Test plan
- [x] 8 unit tests: service CRUD, agent type, proof verification, idempotency, federation
- [x] 4 RPC integration tests: roundtrip with GET verification, invalid proof, nonexistent DID, empty ops
- [x] `cargo test --workspace` -- no regressions
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean