### PR TITLE
fix(node): ensure parent dirs and atomic writes for state persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,6 +996,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tower 0.4.13",

--- a/disentangle-identity/src/lib.rs
+++ b/disentangle-identity/src/lib.rs
@@ -95,6 +95,9 @@ pub enum IdentityError {
 
     #[error("introduction cooldown active")]
     IntroductionCooldown,
+
+    #[error("persistence error: {0}")]
+    PersistenceError(String),
 }
 
 pub type Result<T> = std::result::Result<T, IdentityError>;

--- a/disentangle-node/Cargo.toml
+++ b/disentangle-node/Cargo.toml
@@ -26,3 +26,4 @@ futures = "0.3"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tower = { version = "0.4", features = ["util"] }
 http-body-util = "0.1"
+tempfile = "3"

--- a/disentangle-node/src/identity_state.rs
+++ b/disentangle-node/src/identity_state.rs
@@ -2323,10 +2323,20 @@ impl IdentityStateManager {
         };
 
         let json = serde_json::to_string_pretty(&state)
-            .map_err(|e| IdentityError::InvalidDID(format!("Serialization error: {}", e)))?;
+            .map_err(|e| IdentityError::PersistenceError(format!("Serialization error: {}", e)))?;
 
-        std::fs::write(path, json)
-            .map_err(|e| IdentityError::InvalidDID(format!("File write error: {}", e)))?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                IdentityError::PersistenceError(format!("Failed to create directories: {}", e))
+            })?;
+        }
+
+        let tmp_path = path.with_extension("json.tmp");
+        std::fs::write(&tmp_path, &json)
+            .map_err(|e| IdentityError::PersistenceError(format!("File write error: {}", e)))?;
+
+        std::fs::rename(&tmp_path, path)
+            .map_err(|e| IdentityError::PersistenceError(format!("File rename error: {}", e)))?;
 
         Ok(())
     }
@@ -2334,10 +2344,11 @@ impl IdentityStateManager {
     /// Load state from a JSON file
     pub fn load_from_file(path: &Path) -> Result<Self, IdentityError> {
         let json = std::fs::read_to_string(path)
-            .map_err(|e| IdentityError::DIDNotFound(format!("File read error: {}", e)))?;
+            .map_err(|e| IdentityError::PersistenceError(format!("File read error: {}", e)))?;
 
-        let state: SerializableState = serde_json::from_str(&json)
-            .map_err(|e| IdentityError::InvalidDID(format!("Deserialization error: {}", e)))?;
+        let state: SerializableState = serde_json::from_str(&json).map_err(|e| {
+            IdentityError::PersistenceError(format!("Deserialization error: {}", e))
+        })?;
 
         // Reconstruct did_registry
         let mut did_registry = HashMap::new();

--- a/disentangle-node/tests/test_identity_completeness.rs
+++ b/disentangle-node/tests/test_identity_completeness.rs
@@ -1,8 +1,11 @@
 #[cfg(test)]
 mod tests {
-    use disentangle_identity::{AgentType, ProposalType, VoteChoice};
+    use disentangle_identity::{
+        AgentType, CapabilitySubject, ProposalType, TransactionScope, VoteChoice,
+    };
     use disentangle_node::identity_state::IdentityStateManager;
     use std::path::Path;
+    use tempfile::TempDir;
 
     #[test]
     fn test_introduction_chain_pathfinding() {
@@ -117,5 +120,113 @@ mod tests {
 
         // Clean up
         let _ = std::fs::remove_file(temp_path);
+    }
+
+    #[test]
+    fn save_creates_parent_directories() {
+        let tmp = TempDir::new().unwrap();
+        let nested_path = tmp.path().join("deep").join("nested").join("state.json");
+
+        let mut mgr = IdentityStateManager::new();
+        let (_did, _, _sk) = mgr.register_did(AgentType::Human).unwrap();
+
+        // Should succeed even though deep/nested/ doesn't exist
+        mgr.save_to_file(&nested_path).unwrap();
+        assert!(nested_path.exists());
+
+        // Should load back
+        let loaded = IdentityStateManager::load_from_file(&nested_path).unwrap();
+        assert_eq!(loaded.list_dids().len(), 1);
+    }
+
+    #[test]
+    fn load_nonexistent_file_returns_persistence_error() {
+        let result = IdentityStateManager::load_from_file(Path::new(
+            "/tmp/nonexistent_disentangle_state_12345.json",
+        ));
+        assert!(result.is_err());
+        // Should be PersistenceError, not DIDNotFound
+        let err = match result {
+            Err(e) => format!("{}", e),
+            Ok(_) => panic!("expected error"),
+        };
+        assert!(err.contains("persistence error"));
+    }
+
+    #[test]
+    fn load_corrupt_file_returns_persistence_error() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("corrupt.json");
+        std::fs::write(&path, "this is not valid json {{{").unwrap();
+
+        let result = IdentityStateManager::load_from_file(&path);
+        assert!(result.is_err());
+        let err = match result {
+            Err(e) => format!("{}", e),
+            Ok(_) => panic!("expected error"),
+        };
+        assert!(err.contains("persistence error"));
+    }
+
+    #[test]
+    fn save_atomic_no_partial_files_on_success() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("state.json");
+
+        let mut mgr = IdentityStateManager::new();
+        mgr.register_did(AgentType::Human).unwrap();
+        mgr.save_to_file(&path).unwrap();
+
+        // After successful save, no .tmp file should remain
+        let tmp_path = tmp.path().join("state.json.tmp");
+        assert!(!tmp_path.exists());
+        // But the real file should exist
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn round_trip_preserves_full_state() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("full_state.json");
+
+        let mut mgr = IdentityStateManager::new();
+
+        // Create two DIDs
+        let (did_a, _, sk_a) = mgr.register_did(AgentType::Human).unwrap();
+        let (did_b, _, _sk_b) = mgr
+            .register_did(AgentType::AGI {
+                runtime_attestation: None,
+            })
+            .unwrap();
+
+        // Create an introduction
+        mgr.introduce(&did_a.0, &sk_a, &did_b.0, "colleague")
+            .unwrap();
+
+        // Grant a capability
+        let cap = mgr
+            .create_capability(
+                &did_a.0,
+                &sk_a,
+                CapabilitySubject::Transact {
+                    scope: TransactionScope::All,
+                },
+                vec![],
+                false,
+            )
+            .unwrap();
+
+        // Save
+        mgr.save_to_file(&path).unwrap();
+
+        // Load and verify
+        let loaded = IdentityStateManager::load_from_file(&path).unwrap();
+        assert_eq!(loaded.list_dids().len(), 2);
+        assert!(loaded.get_capability(&cap.id).is_some());
+
+        let chain = loaded
+            .get_introduction_chain(&did_a.0, &did_b.0)
+            .or_else(|| loaded.get_introduction_chain(&did_b.0, &did_a.0));
+        assert!(chain.is_some());
     }
 }

--- a/disentangle-p2p/src/bin/node.rs
+++ b/disentangle-p2p/src/bin/node.rs
@@ -463,11 +463,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (cmd_tx, mut cmd_rx) = mpsc::channel::<NodeCommand>(100);
 
     // Load or create identity state
+    let state_dir = env::var("DISENTANGLE_STATE_DIR").unwrap_or_else(|_| ".".to_string());
+    let state_path = std::path::Path::new(&state_dir).join("disentangle-state.json");
     let identity_manager = {
-        let state_path = std::path::Path::new("./disentangle-state.json");
         if state_path.exists() {
             info!("Loading identity state from {}", state_path.display());
-            match IdentityStateManager::load_from_file(state_path) {
+            match IdentityStateManager::load_from_file(&state_path) {
                 Ok(mgr) => {
                     info!("Identity state loaded successfully");
                     mgr
@@ -656,11 +657,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Setup Ctrl+C handler
     let identity_for_shutdown = shared_state.identity.clone();
+    let shutdown_state_path = state_path.clone();
     tokio::spawn(async move {
         tokio::signal::ctrl_c().await.ok();
         info!("Shutting down. Saving state...");
         let mgr = identity_for_shutdown.lock().await;
-        if let Err(e) = mgr.save_to_file(std::path::Path::new("./disentangle-state.json")) {
+        if let Err(e) = mgr.save_to_file(&shutdown_state_path) {
             warn!("Failed to save state on shutdown: {}", e);
         } else {
             info!("State saved successfully");
@@ -673,7 +675,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tokio::select! {
             _ = save_timer.tick() => {
                 let mgr = shared_state.identity.lock().await;
-                if let Err(e) = mgr.save_to_file(std::path::Path::new("./disentangle-state.json")) {
+                if let Err(e) = mgr.save_to_file(&state_path) {
                     warn!("Periodic save failed: {}", e);
                 } else {
                     debug!("State saved");


### PR DESCRIPTION
## Summary
- Fixes #37: state save permission bug where nodes fail to persist state
- `save_to_file` now creates parent directories (`create_dir_all`) before writing
- Atomic write pattern: writes to `.tmp` file first, then renames to target path
- Adds `PersistenceError` variant to `IdentityError` replacing misused `InvalidDID`/`DIDNotFound` for I/O errors
- State path configurable via `DISENTANGLE_STATE_DIR` env var (defaults to `.`)

## Test plan
- [x] `save_creates_parent_directories` -- nested path with non-existent parents
- [x] `load_nonexistent_file_returns_persistence_error` -- correct error variant
- [x] `load_corrupt_file_returns_persistence_error` -- corrupt JSON handling
- [x] `save_atomic_no_partial_files_on_success` -- no `.tmp` residue
- [x] `round_trip_preserves_full_state` -- DIDs, introductions, capabilities through save/load
- [x] All 549 tests passing, 0 failures