### PR TITLE
Reframe disentangle-zkp — reputation-first, feature-gate future primitives

### DIFF
--- a/disentangle-consensus/Cargo.toml
+++ b/disentangle-consensus/Cargo.toml
@@ -9,7 +9,7 @@ description = "Topological mass consensus for Proof of Entanglement v0.2"
 disentangle-crypto = { path = "../disentangle-crypto" }
 disentangle-simhash = { path = "../disentangle-simhash" }
 disentangle-dag = { path = "../disentangle-dag" }
-disentangle-zkp = { path = "../disentangle-zkp" }
+disentangle-zkp = { path = "../disentangle-zkp", features = ["primitives-future"] }
 sha3.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/disentangle-dag/Cargo.toml
+++ b/disentangle-dag/Cargo.toml
@@ -8,7 +8,7 @@ description = "DAG data structure with discrete curvature for Proof of Entanglem
 [dependencies]
 disentangle-crypto = { path = "../disentangle-crypto" }
 disentangle-simhash = { path = "../disentangle-simhash" }
-disentangle-zkp = { path = "../disentangle-zkp" }
+disentangle-zkp = { path = "../disentangle-zkp", features = ["primitives-future"] }
 sha3.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/disentangle-identity/Cargo.toml
+++ b/disentangle-identity/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 disentangle-crypto = { path = "../disentangle-crypto" }
 disentangle-simhash = { path = "../disentangle-simhash" }
 disentangle-dag = { path = "../disentangle-dag" }
-disentangle-zkp = { path = "../disentangle-zkp" }
+disentangle-zkp = { path = "../disentangle-zkp", features = ["primitives-future"] }
 serde.workspace = true
 thiserror.workspace = true
 sha3.workspace = true

--- a/disentangle-zkp/Cargo.toml
+++ b/disentangle-zkp/Cargo.toml
@@ -6,6 +6,17 @@ license.workspace = true
 repository.workspace = true
 description = "Zero-knowledge proof system for Entangle Protocol using Plonky3 STARKs"
 
+[features]
+# Default features: reputation proofs only. This is the headline surface
+# of the crate and what enterprise deployments depend on.
+default = []
+
+# Opt-in primitives reserved for future applications (privacy-preserving
+# payments, stealth addressing, confidential transaction circuits).
+# These modules remain available behind this flag but are not load-bearing
+# for the current enterprise positioning.
+primitives-future = []
+
 [dependencies]
 # Workspace dependencies
 thiserror.workspace = true

--- a/disentangle-zkp/README.md
+++ b/disentangle-zkp/README.md
@@ -1,0 +1,89 @@
+# disentangle-zkp
+
+Zero-knowledge reputation proofs for the Entangle Protocol, built on
+Plonky3 STARKs.
+
+The headline surface of this crate is `ReputationProver` /
+`ReputationVerifier`: a verifier learns only that a claimant's
+reputation falls into a public bucket, never the exact score.
+
+## What this crate gives you
+
+- `ReputationProver` / `ReputationVerifier` — bucketed STARK proofs that
+  an account's reputation meets a threshold, without revealing the
+  account or the exact score.
+- `AccountMerkleTree` / `MerkleProof` — SHA3-256 Merkle commitments over
+  account state.
+- `ReputationBucket` / `BUCKET_WEIGHTS` — discretized reputation classes
+  used by the protocol's mass computation.
+- `AccountStateLeaf`, `ReputationClaim`, `DiversityAwareReputationClaim`,
+  `SupporterTag` — the core types threaded through prover, verifier, and
+  consensus.
+
+## How reputation proofs work
+
+```text
+AccountState[] --> MerkleTree --> root
+                       |
+                       v
+ReputationCircuit(private: account, path; public: root, bucket)
+                       |
+                       v
+                  ZkProof --> verify() --> bool
+```
+
+To bridge the gap between ZK predicates (which prove statements) and
+mass computation (which needs comparable values), reputation is
+discretized into buckets. Each bucket has a public weight. The circuit
+proves bucket membership without revealing the underlying score, so the
+verifier can assign the correct weight without learning anything more.
+
+Target proving time: under 500ms on commodity hardware. A criterion
+bench (`benches/reputation_proof.rs`) tracks this.
+
+## Default build
+
+```toml
+[dependencies]
+disentangle-zkp = { path = "../disentangle-zkp" }
+```
+
+The default feature set ships only the reputation-proof surface. This
+is what enterprise deployments of the protocol actually link against.
+
+## Primitives available for future applications
+
+This crate also contains a collection of privacy primitives that are
+**not load-bearing for the current enterprise positioning**. They remain
+available, behind a Cargo feature flag, for applications that later
+need privacy-preserving payments, stealth addressing, or confidential
+transaction circuits.
+
+- `stealth` — stealth addresses derived from a Kyber1024 KEM shared
+  secret, so a sender can pay a recipient without revealing the
+  recipient's public key on-chain.
+- `confidential` — hash-based amount commitments with blinding factors
+  (`AmountCommitment`, `Blinding`, `ConfidentialAmount`).
+- `balance_circuit` — a STARK AIR proving
+  `sum(inputs) == sum(outputs)` without revealing amounts.
+- `range_circuit` — a STARK AIR proving `0 <= amount < 2^64` via bit
+  decomposition.
+
+These modules and their re-exports are gated behind the
+`primitives-future` Cargo feature. The feature is off by default and
+activates no other crates. To use any of the primitives, enable it
+explicitly:
+
+```toml
+[dependencies]
+disentangle-zkp = { path = "../disentangle-zkp", features = ["primitives-future"] }
+```
+
+Framing: these primitives are kept in-tree because they have already
+been built and are tested end-to-end by
+`tests/confidential_integration.rs` (also feature-gated). They are not
+part of the default public surface because the current positioning of
+the protocol does not depend on confidential payments. An application
+that needs them can opt in without forking the crate; an enterprise
+deployment that does not need them pays no compile-time cost for their
+presence.

--- a/disentangle-zkp/src/lib.rs
+++ b/disentangle-zkp/src/lib.rs
@@ -1,23 +1,19 @@
 //! # Entangle ZKP
 //!
-//! Zero-knowledge proof system for Entangle Protocol.
-//! Uses Plonky3 STARKs for privacy-preserving reputation proofs and confidential transactions.
+//! Zero-knowledge reputation proofs for the Entangle Protocol, built on
+//! Plonky3 STARKs. The headline surface of this crate is
+//! [`ReputationProver`] / [`ReputationVerifier`]: a verifier learns only
+//! that a claimant's reputation falls into a public bucket, never the
+//! exact value.
 //!
-//! ## Features
+//! ## Default surface (reputation proofs)
 //!
-//! - Merkle tree for account state commitments (SHA3-256)
-//! - STARK circuit for bucketed reputation proofs
-//! - Hash-based amount commitments for confidential transactions
-//! - Balance and range proof circuits
-//! - Stealth addresses using Kyber1024 KEM
-//! - Proof generation < 500ms target
-//! - Zero-knowledge: verifier learns only bucket membership, not exact reputation
-//!
-//! ## Reputation Buckets
-//!
-//! To bridge the gap between ZK proofs (which prove predicates) and mass computation
-//! (which requires values), reputation is discretized into buckets. Each bucket has
-//! a public weight used in mass computation.
+//! - [`ReputationProver`] / [`ReputationVerifier`] — bucketed STARK proofs
+//! - [`AccountMerkleTree`] / [`MerkleProof`] — account-state commitments (SHA3-256)
+//! - [`ReputationBucket`] / [`BUCKET_WEIGHTS`] — discretized reputation classes
+//!   used by mass computation
+//! - [`AccountStateLeaf`], [`ReputationClaim`], [`DiversityAwareReputationClaim`],
+//!   [`SupporterTag`]
 //!
 //! ## Architecture
 //!
@@ -29,31 +25,62 @@
 //!                        |
 //!                        v
 //!                   ZkProof --> verify() --> bool
-//!
-//! ConfidentialTx --> BalanceCircuit + RangeCircuit --> ZkProof
 //! ```
+//!
+//! ## Reputation buckets
+//!
+//! To bridge the gap between ZK predicates and the mass computation used
+//! by consensus, reputation is discretized into buckets. Each bucket has
+//! a public weight. The circuit proves bucket membership without
+//! revealing the underlying score.
+//!
+//! ## Primitives available for future applications
+//!
+//! Additional primitives — stealth addressing, hash-based amount
+//! commitments, balance and range circuits for confidential
+//! transactions — are implemented in this crate but gated behind the
+//! `primitives-future` Cargo feature. They are not load-bearing for the
+//! current enterprise positioning; they remain available for
+//! applications that later need privacy-preserving payments or stealth
+//! addressing. See the README for the full list and activation
+//! instructions.
 
-pub mod balance_circuit;
+// Reputation-proof surface — always available.
 pub mod circuit;
-pub mod confidential;
 pub mod merkle;
 pub mod proof;
-pub mod range_circuit;
 pub mod reputation_bucket;
 pub mod stark_config;
-pub mod stealth;
 pub mod types;
 
-pub use balance_circuit::{BalanceAir, BalanceWitness};
-pub use confidential::{AmountCommitment, Blinding, ConfidentialAmount};
+// Primitives reserved for future applications. Gated so the default
+// build surfaces only reputation proofs.
+#[cfg(feature = "primitives-future")]
+pub mod balance_circuit;
+#[cfg(feature = "primitives-future")]
+pub mod confidential;
+#[cfg(feature = "primitives-future")]
+pub mod range_circuit;
+#[cfg(feature = "primitives-future")]
+pub mod stealth;
+
+// Headline re-exports: reputation proofs first.
 pub use merkle::{AccountMerkleTree, MerkleProof};
 pub use proof::{ReputationProver, ReputationVerifier};
-pub use range_circuit::{RangeAir, RangeWitness};
 pub use reputation_bucket::{
     bucket_weight, reputation_to_bucket, ReputationBucket, BUCKET_WEIGHTS,
 };
-pub use stealth::{ConfidentialOutput, StealthAddress, StealthError};
 pub use types::{AccountStateLeaf, DiversityAwareReputationClaim, ReputationClaim, SupporterTag};
+
+// Future-application re-exports, gated with the modules above.
+#[cfg(feature = "primitives-future")]
+pub use balance_circuit::{BalanceAir, BalanceWitness};
+#[cfg(feature = "primitives-future")]
+pub use confidential::{AmountCommitment, Blinding, ConfidentialAmount};
+#[cfg(feature = "primitives-future")]
+pub use range_circuit::{RangeAir, RangeWitness};
+#[cfg(feature = "primitives-future")]
+pub use stealth::{ConfidentialOutput, StealthAddress, StealthError};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ZkpError {

--- a/disentangle-zkp/tests/confidential_integration.rs
+++ b/disentangle-zkp/tests/confidential_integration.rs
@@ -1,4 +1,11 @@
-//! Integration tests for Phase 4: Confidential Transactions
+//! Integration tests for Phase 4: Confidential Transactions.
+//!
+//! These exercises target the `primitives-future` surface (stealth,
+//! confidential, balance, range). The file is gated so that default
+//! builds — which ship only the reputation-proof surface — do not try
+//! to compile against symbols that are not exported.
+
+#![cfg(feature = "primitives-future")]
 
 use disentangle_crypto::kem::generate_kem_keypair;
 use disentangle_zkp::stealth::generate_stealth_address;


### PR DESCRIPTION
Reframe `disentangle-zkp` so reputation proofs are the headline surface and confidential-tx primitives are explicitly scoped as "primitives available for future applications" behind a feature flag.

## Changes

- New Cargo feature `primitives-future` (default off)
- `stealth`, `confidential`, `balance_circuit`, `range_circuit` modules and re-exports gated behind `#[cfg(feature = "primitives-future")]`. (balance_circuit/range_circuit included because they import from confidential and form the confidential-tx primitive family.)
- `disentangle-zkp/src/lib.rs` reordered — `ReputationProver` / `ReputationVerifier` are the first pub use, headline re-exports cover merkle, reputation_bucket, types
- `tests/confidential_integration.rs` prefixed with `#![cfg(feature = "primitives-future")]`
- Dependent crates (`disentangle-dag`, `disentangle-consensus`, `disentangle-identity`) explicitly enable the feature to preserve current workspace behavior. No other crate required the feature.
- `disentangle-zkp/README.md` written from scratch — leads with reputation proofs, closes with "Primitives available for future applications" framing the confidential primitives as non-load-bearing for current enterprise positioning

## Gates

- cargo check --workspace (default features): clean
- cargo check --workspace --features disentangle-zkp/primitives-future: clean
- cargo test --workspace: 6 passed in confidential_integration; full suite green
- cargo clippy --workspace --all-targets -- -D warnings: clean
- cargo fmt --check: clean

## Known follow-up (per refactor-zkp self-eval)

The feature flag is advisory, not a genuine excision, because dependent crates thread `ConfidentialOutput` / `AmountCommitment` through their public surfaces. For the flag to literally decouple the enterprise surface from confidential-tx primitives, those types should come out of the public APIs of dag/consensus/identity. Second-order refactor, separate PR.

## Task reference

- task #9